### PR TITLE
fix: release workflow symbol format and NuGet push resilience

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,11 @@ jobs:
           dotnet pack Tharga.Team.Service/Tharga.Team.Service.csproj -c Release --no-build -o ./artifacts /p:PackageVersion=${{ steps.version.outputs.version }}
 
       - name: Push to NuGet
-        run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: |
+          for pkg in ./artifacts/*.nupkg; do
+            echo "Pushing $pkg..."
+            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate || true
+          done
 
       - name: Create GitHub Release
         env:

--- a/Tharga.Team.Blazor/Tharga.Team.Blazor.csproj
+++ b/Tharga.Team.Blazor/Tharga.Team.Blazor.csproj
@@ -16,6 +16,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSource>true</IncludeSource>
     <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <InternalsVisibleTo>Tharga.Team.Blazor.Tests</InternalsVisibleTo>
   </PropertyGroup>
   <PropertyGroup>

--- a/Tharga.Team.MongoDB/Tharga.Team.MongoDB.csproj
+++ b/Tharga.Team.MongoDB/Tharga.Team.MongoDB.csproj
@@ -16,6 +16,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSource>true</IncludeSource>
     <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <PropertyGroup>
     <NoWarn>1701;1702;CS1591</NoWarn>

--- a/Tharga.Team.Service/Tharga.Team.Service.csproj
+++ b/Tharga.Team.Service/Tharga.Team.Service.csproj
@@ -15,6 +15,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSource>true</IncludeSource>
     <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <PropertyGroup>
     <NoWarn>1701;1702;CS1591</NoWarn>

--- a/Tharga.Team/Tharga.Team.csproj
+++ b/Tharga.Team/Tharga.Team.csproj
@@ -16,6 +16,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSource>true</IncludeSource>
     <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <PropertyGroup>
     <NoWarn>1701;1702;CS1591</NoWarn>


### PR DESCRIPTION
## Summary

- Set `SymbolPackageFormat=snupkg` in all 4 package csproj files — NuGet.org requires the snupkg format, the old `.symbols.nupkg` format was being rejected
- Push NuGet packages individually with `|| true` so a single package failure (e.g. 403 on one package) doesn't block the GitHub Release step

## Note

The 403 error on `Tharga.Team.Blazor` is a NuGet.org API key permission issue — the key needs to be scoped to include all 4 `Tharga.Team*` packages. This is configured on nuget.org, not in code.

## Test plan

- [ ] Merge this PR
- [ ] Update NuGet API key to include all packages
- [ ] Run Release workflow again