### PR TITLE
fix: audit logging + MongoDB monitor tracking

### DIFF
--- a/Tharga.Team.MongoDB/Tharga.Team.MongoDB.csproj
+++ b/Tharga.Team.MongoDB/Tharga.Team.MongoDB.csproj
@@ -28,7 +28,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Tharga.MongoDB" Version="2.10.1" />
+    <PackageReference Include="Tharga.MongoDB" Version="2.10.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Team\Tharga.Team.csproj" />

--- a/Tharga.Team.MongoDB/ThargaTeamRegistration.cs
+++ b/Tharga.Team.MongoDB/ThargaTeamRegistration.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Tharga.MongoDB;
 
 namespace Tharga.Team.MongoDB;
 
@@ -24,6 +25,7 @@ public static class ThargaTeamRegistration
 
             services.AddTransient(userRepositoryInterfaceType, userRepositoryImplementationType);
             services.AddTransient(userRepositoryCollectionInterfaceType, userRepositoryCollectionImplementationType);
+            services.TrackMongoCollection(userRepositoryCollectionInterfaceType, userRepositoryCollectionImplementationType);
         }
 
         if (o._teamEntity != null && o._teamMemberModel != null)
@@ -39,6 +41,7 @@ public static class ThargaTeamRegistration
 
             services.AddTransient(teamRepositoryInterfaceType, teamRepositoryImplementationType);
             services.AddTransient(teamRepositoryCollectionInterfaceType, teamRepositoryCollectionImplementationType);
+            services.TrackMongoCollection(teamRepositoryCollectionInterfaceType, teamRepositoryCollectionImplementationType);
         }
     }
 }

--- a/Tharga.Team.Service/AccessLevelProxy.cs
+++ b/Tharga.Team.Service/AccessLevelProxy.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics;
 using System.Reflection;
 using Microsoft.AspNetCore.Http;
+using Tharga.Team.Service.Audit;
 
 namespace Tharga.Team.Service;
 
@@ -7,17 +9,20 @@ namespace Tharga.Team.Service;
 /// DispatchProxy that intercepts service method calls and enforces
 /// <see cref="RequireAccessLevelAttribute"/> by reading TeamKey and AccessLevel
 /// claims from HttpContext. Methods without the attribute are blocked (fail-closed).
+/// Logs audit entries when IAuditLogger is available.
 /// </summary>
 public class AccessLevelProxy<T> : DispatchProxy where T : class
 {
     private T _target;
     private IHttpContextAccessor _httpContextAccessor;
+    private IAuditLogger _auditLogger;
 
-    public static T Create(T target, IHttpContextAccessor httpContextAccessor)
+    public static T Create(T target, IHttpContextAccessor httpContextAccessor, IAuditLogger auditLogger = null)
     {
         var proxy = Create<T, AccessLevelProxy<T>>() as AccessLevelProxy<T>;
         proxy._target = target;
         proxy._httpContextAccessor = httpContextAccessor;
+        proxy._auditLogger = auditLogger;
         return proxy as T;
     }
 
@@ -29,9 +34,81 @@ public class AccessLevelProxy<T> : DispatchProxy where T : class
                 $"Method '{typeof(T).Name}.{targetMethod.Name}' is missing the [RequireAccessLevel] attribute. " +
                 $"All methods on services registered with AddScopedWithAccessLevel must declare their required access level.");
 
-        CheckAccessLevel(attribute.MinimumLevel);
+        var sw = Stopwatch.StartNew();
 
-        return targetMethod.Invoke(_target, args);
+        try
+        {
+            CheckAccessLevel(attribute.MinimumLevel);
+
+            var result = targetMethod.Invoke(_target, args);
+            sw.Stop();
+
+            LogAudit(attribute.MinimumLevel, targetMethod.Name, sw.ElapsedMilliseconds, true);
+
+            return result;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            sw.Stop();
+            LogAudit(attribute.MinimumLevel, targetMethod.Name, sw.ElapsedMilliseconds, false,
+                AuditEventType.AccessLevelDenial, ex.Message);
+            throw;
+        }
+        catch (TargetInvocationException tie)
+        {
+            sw.Stop();
+            LogAudit(attribute.MinimumLevel, targetMethod.Name, sw.ElapsedMilliseconds, false,
+                errorMessage: tie.InnerException?.Message);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            LogAudit(attribute.MinimumLevel, targetMethod.Name, sw.ElapsedMilliseconds, false,
+                errorMessage: ex.Message);
+            throw;
+        }
+    }
+
+    private void LogAudit(AccessLevel minimumLevel, string methodName, long durationMs, bool success,
+        AuditEventType? eventType = null, string errorMessage = null)
+    {
+        if (_auditLogger == null) return;
+
+        var user = _httpContextAccessor.HttpContext?.User;
+        var identity = user?.Identity;
+
+        var callerSource = identity?.AuthenticationType switch
+        {
+            ApiKeyConstants.SchemeName => AuditCallerSource.Api,
+            "Cookies" or "AuthenticationTypes.Federation" => AuditCallerSource.Web,
+            _ => AuditCallerSource.Unknown
+        };
+
+        var entry = new AuditEntry
+        {
+            Timestamp = DateTime.UtcNow,
+            EventType = eventType ?? AuditEventType.ServiceCall,
+            Feature = typeof(T).Name,
+            Action = methodName,
+            MethodName = methodName,
+            DurationMs = durationMs,
+            Success = success,
+            ErrorMessage = errorMessage,
+            CallerType = callerSource == AuditCallerSource.Api ? AuditCallerType.ApiKey : AuditCallerType.User,
+            CorrelationId = Guid.TryParse(_httpContextAccessor.HttpContext?.TraceIdentifier, out var traceId) ? traceId : Guid.NewGuid(),
+            CallerIdentity = user?.FindFirst(System.Security.Claims.ClaimTypes.Name)?.Value
+                ?? user?.FindFirst("preferred_username")?.Value
+                ?? user?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+                ?? user?.FindFirst("name")?.Value,
+            TeamKey = user?.FindFirst(TeamClaimTypes.TeamKey)?.Value,
+            AccessLevel = user?.FindFirst(TeamClaimTypes.AccessLevel)?.Value,
+            CallerSource = callerSource,
+            ScopeChecked = $"AccessLevel>={minimumLevel}",
+            ScopeResult = success ? AuditScopeResult.Allowed : AuditScopeResult.Denied,
+        };
+
+        _auditLogger.Log(entry);
     }
 
     private RequireAccessLevelAttribute GetAttribute(MethodInfo methodInfo)

--- a/Tharga.Team.Service/AccessLevelServiceCollectionExtensions.cs
+++ b/Tharga.Team.Service/AccessLevelServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Tharga.Team;
+using Tharga.Team.Service.Audit;
 
 namespace Tharga.Team.Service;
 
@@ -12,6 +13,7 @@ public static class AccessLevelServiceCollectionExtensions
     /// <summary>
     /// Registers a scoped service wrapped in an <see cref="AccessLevelProxy{T}"/>
     /// that enforces <see cref="RequireAccessLevelAttribute"/> on every method call.
+    /// Logs audit entries when IAuditLogger is available.
     /// </summary>
     public static IServiceCollection AddScopedWithAccessLevel<TService, TImplementation>(this IServiceCollection services)
         where TService : class
@@ -22,7 +24,8 @@ public static class AccessLevelServiceCollectionExtensions
         {
             var target = sp.GetRequiredService<TImplementation>();
             var httpContextAccessor = sp.GetRequiredService<IHttpContextAccessor>();
-            return AccessLevelProxy<TService>.Create(target, httpContextAccessor);
+            var auditLogger = sp.GetService<IAuditLogger>();
+            return AccessLevelProxy<TService>.Create(target, httpContextAccessor, auditLogger);
         });
         return services;
     }

--- a/Tharga.Team.Service/Audit/AuditEventType.cs
+++ b/Tharga.Team.Service/Audit/AuditEventType.cs
@@ -6,6 +6,7 @@ public enum AuditEventType
     AuthSuccess,
     AuthFailure,
     ScopeDenial,
+    AccessLevelDenial,
     DataChange,
     RateLimit
 }


### PR DESCRIPTION
## Summary
- **AccessLevelProxy audit logging** — now logs service calls and access level denials, matching ScopeProxy behavior. Added `AccessLevelDenial` to `AuditEventType`.
- **MongoDB monitor tracking** — `AddThargaTeamRepository` now calls `TrackMongoCollection` for Team and User collections so they appear as "in code" in the database monitor instead of "NotInCode". Requires Tharga.MongoDB 2.10.2.

## Test plan
- [ ] Verify AccessLevelProxy logs audit entries on successful calls
- [ ] Verify AccessLevelProxy logs AccessLevelDenial on denied access
- [ ] Verify Team/User collections show as registered in MongoDB monitor
- [ ] All 189 tests pass