### PR TITLE
fix: prerelease artifact version mismatch in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,13 +93,23 @@ jobs:
           echo "version=$PRE_VERSION" >> "$GITHUB_OUTPUT"
           echo "Computed pre-release version: $PRE_VERSION"
 
-      - name: Pack
+      - name: Pack (stable — push to master)
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         run: |
-          dotnet pack Tharga.Team/Tharga.Team.csproj -c Release --no-build -o ./artifacts /p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack Tharga.Team.Blazor/Tharga.Team.Blazor.csproj -c Release --no-build -o ./artifacts /p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack Tharga.Team.MongoDB/Tharga.Team.MongoDB.csproj -c Release --no-build -o ./artifacts /p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack Tharga.Team.Service/Tharga.Team.Service.csproj -c Release --no-build -o ./artifacts /p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack Tharga.Platform.Mcp/Tharga.Platform.Mcp.csproj -c Release --no-build -o ./artifacts /p:PackageVersion=${{ steps.version.outputs.version }}
+          dotnet pack Tharga.Team/Tharga.Team.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
+          dotnet pack Tharga.Team.Blazor/Tharga.Team.Blazor.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
+          dotnet pack Tharga.Team.MongoDB/Tharga.Team.MongoDB.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
+          dotnet pack Tharga.Team.Service/Tharga.Team.Service.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
+          dotnet pack Tharga.Platform.Mcp/Tharga.Platform.Mcp.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
+
+      - name: Pack (pre-release — pull request)
+        if: github.event_name == 'pull_request'
+        run: |
+          dotnet pack Tharga.Team/Tharga.Team.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.preversion.outputs.version }}
+          dotnet pack Tharga.Team.Blazor/Tharga.Team.Blazor.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.preversion.outputs.version }}
+          dotnet pack Tharga.Team.MongoDB/Tharga.Team.MongoDB.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.preversion.outputs.version }}
+          dotnet pack Tharga.Team.Service/Tharga.Team.Service.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.preversion.outputs.version }}
+          dotnet pack Tharga.Platform.Mcp/Tharga.Platform.Mcp.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.preversion.outputs.version }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Fixes a latent bug inherited from the Tharga.Crawler build.yml template.

The `Pack` step always stamped the **stable** version into the .nupkg, even on PR runs. If the `prerelease` job then ran on a PR, it would download that artifact and push the stable version to NuGet under a GitHub Release tagged as pre-release — minting the stable patch on NuGet before the PR merges.

`--skip-duplicate` means whichever PR runs first wins that patch number.

Not damaging yet (the `prerelease` environment requires manual approval, which hasn't fired), but worth fixing before it does.

## Fix

Split the single `Pack` step into two conditional steps:

- **Stable** — runs on `push` to `master`, uses `steps.version.outputs.version`
- **Pre-release** — runs on `pull_request`, uses `steps.preversion.outputs.version`

Matches the pattern applied in `Tharga.Mcp` `feature/prerelease-version-fix`.

## Test plan

- [ ] This PR's build job runs with the pre-release version (visible in logs)
- [ ] Build + security checks pass