### PR TITLE
refactor: rename AddMcpPlatform to AddPlatform

### DIFF
--- a/Tharga.Platform.Mcp.Tests/AddPlatformTests.cs
+++ b/Tharga.Platform.Mcp.Tests/AddPlatformTests.cs
@@ -5,7 +5,7 @@ using Tharga.Team;
 
 namespace Tharga.Platform.Mcp.Tests;
 
-public class AddMcpPlatformTests
+public class AddPlatformTests
 {
     [Fact]
     public void ReplacesDefaultContextAccessorWithHttpContextBacked()
@@ -14,7 +14,7 @@ public class AddMcpPlatformTests
 
         services.AddThargaMcp(mcp =>
         {
-            mcp.AddMcpPlatform();
+            mcp.AddPlatform();
         });
 
         var provider = services.BuildServiceProvider();
@@ -30,7 +30,7 @@ public class AddMcpPlatformTests
 
         services.AddThargaMcp(mcp =>
         {
-            mcp.AddMcpPlatform(o => o.ExposeSystemResources = false);
+            mcp.AddPlatform(o => o.ExposeSystemResources = false);
         });
 
         Assert.DoesNotContain(services, d => d.ServiceType == typeof(PlatformSystemResourceProvider));
@@ -43,7 +43,7 @@ public class AddMcpPlatformTests
 
         services.AddThargaMcp(mcp =>
         {
-            mcp.AddMcpPlatform(o => o.ExposeSystemResources = true);
+            mcp.AddPlatform(o => o.ExposeSystemResources = true);
         });
 
         Assert.Contains(services, d => d.ServiceType == typeof(PlatformSystemResourceProvider));
@@ -59,7 +59,7 @@ public class AddMcpPlatformTests
 
         services.AddThargaMcp(mcp =>
         {
-            mcp.AddMcpPlatform();
+            mcp.AddPlatform();
         });
 
         var provider = services.BuildServiceProvider();
@@ -75,7 +75,7 @@ public class AddMcpPlatformTests
 
         services.AddThargaMcp(mcp =>
         {
-            mcp.AddMcpPlatform();
+            mcp.AddPlatform();
         });
 
         var provider = services.BuildServiceProvider();
@@ -91,7 +91,7 @@ public class AddMcpPlatformTests
 
         services.AddThargaMcp(mcp =>
         {
-            mcp.AddMcpPlatform(o => o.DeveloperRole = "SuperAdmin");
+            mcp.AddPlatform(o => o.DeveloperRole = "SuperAdmin");
         });
 
         var provider = services.BuildServiceProvider();
@@ -99,4 +99,20 @@ public class AddMcpPlatformTests
 
         Assert.Equal("SuperAdmin", options.Value.DeveloperRole);
     }
+
+    [Fact]
+#pragma warning disable CS0618 // Type or member is obsolete
+    public void ObsoleteAddMcpPlatform_ForwardsToAddPlatform()
+    {
+        var services = new ServiceCollection();
+
+        services.AddThargaMcp(mcp =>
+        {
+            mcp.AddMcpPlatform();
+        });
+
+        var provider = services.BuildServiceProvider();
+        Assert.IsType<HttpContextMcpContextAccessor>(provider.GetRequiredService<IMcpContextAccessor>());
+    }
+#pragma warning restore CS0618
 }

--- a/Tharga.Platform.Mcp/HttpContextMcpContextAccessor.cs
+++ b/Tharga.Platform.Mcp/HttpContextMcpContextAccessor.cs
@@ -6,7 +6,7 @@ namespace Tharga.Platform.Mcp;
 
 /// <summary>
 /// <see cref="IMcpContextAccessor"/> implementation that builds an <see cref="IMcpContext"/> from the current
-/// <see cref="HttpContext"/> on demand. Replaces the default AsyncLocal-backed accessor when <c>AddMcpPlatform</c>
+/// <see cref="HttpContext"/> on demand. Replaces the default AsyncLocal-backed accessor when <c>AddPlatform</c>
 /// is registered.
 /// </summary>
 /// <remarks>

--- a/Tharga.Platform.Mcp/McpPlatformBuilderExtensions.cs
+++ b/Tharga.Platform.Mcp/McpPlatformBuilderExtensions.cs
@@ -19,7 +19,7 @@ public static class McpPlatformBuilderExtensions
     /// Registers the Platform bridge: populates <see cref="IMcpContext"/> from the current <see cref="HttpContext"/>,
     /// enables <see cref="IMcpScopeChecker"/>, and registers built-in <c>mcp:*</c> scopes.
     /// </summary>
-    public static IThargaMcpBuilder AddMcpPlatform(this IThargaMcpBuilder builder, Action<McpPlatformOptions> configure = null)
+    public static IThargaMcpBuilder AddPlatform(this IThargaMcpBuilder builder, Action<McpPlatformOptions> configure = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
@@ -69,4 +69,9 @@ public static class McpPlatformBuilderExtensions
 
         return mapped;
     }
+
+    /// <summary>Obsolete alias for <see cref="AddPlatform"/>.</summary>
+    [Obsolete("Use AddPlatform() instead. Will be removed in a future release.")]
+    public static IThargaMcpBuilder AddMcpPlatform(this IThargaMcpBuilder builder, Action<McpPlatformOptions> configure = null)
+        => builder.AddPlatform(configure);
 }

--- a/Tharga.Platform.Mcp/McpScopes.cs
+++ b/Tharga.Platform.Mcp/McpScopes.cs
@@ -1,7 +1,7 @@
 namespace Tharga.Platform.Mcp;
 
 /// <summary>
-/// Built-in MCP scope constants registered by <c>AddMcpPlatform</c>.
+/// Built-in MCP scope constants registered by <c>AddPlatform</c>.
 /// Provider packages (e.g. <c>Tharga.MongoDB.Mcp</c>) register their own scopes in the same <c>mcp:*</c> namespace.
 /// </summary>
 public static class McpScopes

--- a/Tharga.Platform.Mcp/PlatformSystemResourceProvider.cs
+++ b/Tharga.Platform.Mcp/PlatformSystemResourceProvider.cs
@@ -8,7 +8,7 @@ namespace Tharga.Platform.Mcp;
 /// <summary>
 /// Read-only MCP resource provider that surfaces system-scope Platform data for diagnostic use.
 /// Only available to callers with the Developer role (see <see cref="IMcpContext.IsDeveloper"/>).
-/// Registered by <c>AddMcpPlatform</c> when <see cref="McpPlatformOptions.ExposeSystemResources"/> is true.
+/// Registered by <c>AddPlatform</c> when <see cref="McpPlatformOptions.ExposeSystemResources"/> is true.
 /// </summary>
 public sealed class PlatformSystemResourceProvider : IMcpResourceProvider
 {

--- a/Tharga.Platform.Mcp/README.md
+++ b/Tharga.Platform.Mcp/README.md
@@ -18,7 +18,7 @@ Platform bridge for [Tharga.Mcp](https://www.nuget.org/packages/Tharga.Mcp). Con
 ```csharp
 builder.Services.AddThargaMcp(mcp =>
 {
-    mcp.AddMcpPlatform();        // bridge to Platform auth/scopes/audit
+    mcp.AddPlatform();        // bridge to Platform auth/scopes/audit
     // ... other provider packages (e.g. mcp.AddMongoDB())
 });
 
@@ -32,7 +32,7 @@ Expose read-only diagnostic data under `platform://system/*` for callers with th
 ```csharp
 builder.Services.AddThargaMcp(mcp =>
 {
-    mcp.AddMcpPlatform(o =>
+    mcp.AddPlatform(o =>
     {
         o.ExposeSystemResources = true;
     });

--- a/Tharga.Platform.Sample/Program.cs
+++ b/Tharga.Platform.Sample/Program.cs
@@ -42,7 +42,7 @@ builder.AddThargaPlatform(o =>
 });
 builder.Services.AddThargaMcp(mcp =>
 {
-    mcp.AddMcpPlatform();
+    mcp.AddPlatform();
 });
 
 builder.AddMongoDB();


### PR DESCRIPTION
## Summary

Renames `IThargaMcpBuilder.AddMcpPlatform` to `AddPlatform` to match the convention documented in the MCP master plan:

```csharp
builder.Services.AddThargaMcp(mcp =>
{
    mcp.AddPlatform();    // bridge: Platform → Mcp
    mcp.AddMongoDB();     // provider
});
```

Inside the `AddThargaMcp` callback scope, the `Mcp` prefix is redundant — each package names its hook after the thing being added (Platform, MongoDB, Cache, etc).

## Changes

- New primary name: `IThargaMcpBuilder.AddPlatform(...)`
- Old name kept as `[Obsolete]` forwarder for one release cycle
- README, doc comments, sample (`Tharga.Platform.Sample`), and tests updated to the new name
- New test verifies the obsolete forwarder still works

## Tests

236 total passing. 1 new test for the forwarder.

## Test plan

- [ ] Build + security checks pass
- [ ] Consumers using the old `AddMcpPlatform()` see the obsolete warning but still compile and work