### PR TITLE
feat: upgrade Tharga.Mcp to 0.1.2 + derive McpScope from claims

### DIFF
--- a/Tharga.Platform.Mcp.Tests/HttpContextMcpContextAccessorTests.cs
+++ b/Tharga.Platform.Mcp.Tests/HttpContextMcpContextAccessorTests.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
+using Tharga.Mcp;
 using Tharga.Platform.Mcp;
 using Tharga.Team;
 
@@ -50,5 +51,72 @@ public class HttpContextMcpContextAccessorTests
 
         // Setter should not throw even though it's a no-op
         sut.Current = null;
+    }
+
+    [Fact]
+    public void Scope_Is_System_When_Caller_Has_Developer_Role()
+    {
+        var ctx = CreateContext(new Claim(ClaimTypes.Role, "Developer"));
+
+        Assert.Equal(McpScope.System, ctx.Scope);
+        Assert.True(ctx.IsDeveloper);
+    }
+
+    [Fact]
+    public void Scope_Is_System_When_Caller_Has_IsSystemKey_Claim()
+    {
+        var ctx = CreateContext(new Claim(TeamClaimTypes.IsSystemKey, "true"));
+
+        Assert.Equal(McpScope.System, ctx.Scope);
+    }
+
+    [Fact]
+    public void Scope_Is_Team_When_Caller_Has_TeamKey_But_No_Developer_Role()
+    {
+        var ctx = CreateContext(new Claim(TeamClaimTypes.TeamKey, "team-1"));
+
+        Assert.Equal(McpScope.Team, ctx.Scope);
+        Assert.False(ctx.IsDeveloper);
+    }
+
+    [Fact]
+    public void Scope_Is_User_When_Caller_Has_Neither_Developer_Nor_Team()
+    {
+        var ctx = CreateContext(new Claim(ClaimTypes.NameIdentifier, "user-1"));
+
+        Assert.Equal(McpScope.User, ctx.Scope);
+    }
+
+    [Fact]
+    public void DeveloperRole_Takes_Precedence_Over_TeamKey()
+    {
+        var ctx = CreateContext(
+            new Claim(TeamClaimTypes.TeamKey, "team-1"),
+            new Claim(ClaimTypes.Role, "Developer"));
+
+        Assert.Equal(McpScope.System, ctx.Scope);
+    }
+
+    [Fact]
+    public void Custom_DeveloperRole_Is_Honored()
+    {
+        var options = Options.Create(new McpPlatformOptions { DeveloperRole = "SuperAdmin" });
+        var identity = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, "SuperAdmin") }, "TestAuth");
+        var httpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(httpContext);
+        var sut = new HttpContextMcpContextAccessor(accessor, options);
+
+        Assert.Equal(McpScope.System, sut.Current.Scope);
+    }
+
+    private static IMcpContext CreateContext(params Claim[] claims)
+    {
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var httpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(httpContext);
+        var sut = new HttpContextMcpContextAccessor(accessor, Options.Create(new McpPlatformOptions()));
+        return sut.Current;
     }
 }

--- a/Tharga.Platform.Mcp/HttpContextMcpContextAccessor.cs
+++ b/Tharga.Platform.Mcp/HttpContextMcpContextAccessor.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using Tharga.Mcp;
+using Tharga.Team;
 
 namespace Tharga.Platform.Mcp;
 
@@ -30,10 +31,23 @@ public sealed class HttpContextMcpContextAccessor : IMcpContextAccessor
             var ctx = _httpContextAccessor.HttpContext;
             if (ctx == null) return null;
 
-            // The Phase 0 single-endpoint design doesn't carry per-call scope through the transport.
-            // Callers can still read user/team/developer claims. Scope is User by default and providers
-            // should enforce their own declared scope via context.IsDeveloper / context.TeamId.
-            return new PlatformMcpContext(ctx.User, McpScope.User, _options.DeveloperRole);
+            var user = ctx.User;
+            // Derive scope from claims so the Tharga.Mcp dispatcher's hierarchy filter
+            // (p.Scope <= current.Scope, since Tharga.Mcp 0.1.2) can see providers at the
+            // caller's level and below.
+            //
+            // - Developer role (or system API key) → System scope sees everything
+            // - TeamKey claim → Team scope sees Team + User providers
+            // - Otherwise → User scope
+            var scope =
+                (user?.IsInRole(_options.DeveloperRole) ?? false)
+                    || (user?.HasClaim(TeamClaimTypes.IsSystemKey, "true") ?? false)
+                    ? McpScope.System
+                : !string.IsNullOrEmpty(user?.FindFirst(TeamClaimTypes.TeamKey)?.Value)
+                    ? McpScope.Team
+                : McpScope.User;
+
+            return new PlatformMcpContext(user, scope, _options.DeveloperRole);
         }
         set
         {

--- a/Tharga.Platform.Mcp/McpPlatformBuilderExtensions.cs
+++ b/Tharga.Platform.Mcp/McpPlatformBuilderExtensions.cs
@@ -53,21 +53,17 @@ public static class McpPlatformBuilderExtensions
 
     /// <summary>
     /// Maps the MCP endpoint and applies Platform authentication policy.
-    /// When <see cref="ThargaMcpOptions.RequireAuth"/> is true (the default), the endpoint requires an authenticated caller.
     /// </summary>
+    /// <remarks>
+    /// Obsolete since Tharga.Mcp 0.1.2 — <c>UseThargaMcp()</c> now reads
+    /// <see cref="ThargaMcpOptions.RequireAuth"/> and applies <c>RequireAuthorization()</c> itself.
+    /// Consumers should call <c>app.UseThargaMcp()</c> directly.
+    /// </remarks>
+    [Obsolete("Use app.UseThargaMcp() directly — it honors ThargaMcpOptions.RequireAuth since Tharga.Mcp 0.1.2. Will be removed in a future release.")]
     public static IEndpointConventionBuilder MapMcpPlatform(this IEndpointRouteBuilder endpoints)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
-
-        var mcpOptions = endpoints.ServiceProvider.GetRequiredService<ThargaMcpOptions>();
-        var mapped = endpoints.UseThargaMcp();
-
-        if (mcpOptions.RequireAuth)
-        {
-            mapped.RequireAuthorization();
-        }
-
-        return mapped;
+        return endpoints.UseThargaMcp();
     }
 
     /// <summary>Obsolete alias for <see cref="AddPlatform"/>.</summary>

--- a/Tharga.Platform.Mcp/Tharga.Platform.Mcp.csproj
+++ b/Tharga.Platform.Mcp/Tharga.Platform.Mcp.csproj
@@ -31,7 +31,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Tharga.Mcp" Version="0.1.1" />
+    <PackageReference Include="Tharga.Mcp" Version="0.1.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Team.Service\Tharga.Team.Service.csproj" />


### PR DESCRIPTION
## Summary

Two connected changes that together unblock System-scope MCP providers (our own `PlatformSystemResourceProvider` and `Tharga.MongoDB.Mcp`) for consumers like Quilt4Net Server and PlutusWave.

## Changes

### 1. Bump `Tharga.Mcp` 0.1.1 → 0.1.2

The 0.1.2 release:
- Switches the dispatcher scope filter from strict equality to hierarchy semantics (`provider.Scope <= caller.Scope`)
- Makes `UseThargaMcp()` honor `ThargaMcpOptions.RequireAuth` automatically — `MapMcpPlatform()` is no longer needed as a wrapper

### 2. Derive `McpScope` from claims in `HttpContextMcpContextAccessor`

Previously the accessor hardcoded `McpScope.User` for every caller, which meant the dispatcher hierarchy filter never let System providers through — even for Developers with a system API key.

New derivation:

| Caller | Resolved scope |
|--------|----------------|
| Has Developer role OR `IsSystemKey=true` | `McpScope.System` |
| Has `TeamKey` claim | `McpScope.Team` |
| Otherwise | `McpScope.User` |

The dispatcher's hierarchy filter then makes providers at the caller's level and below visible (Developer sees System + Team + User providers; team-scoped caller sees Team + User; anonymous-ish sees only User).

### 3. Deprecate `MapMcpPlatform()`

Since `UseThargaMcp()` in 0.1.2 applies `RequireAuthorization()` from the option itself, the Platform-specific wrapper is redundant. Marked `[Obsolete]` — consumers should call `app.UseThargaMcp()` directly.

## Tests

6 new tests covering every scope-derivation branch plus the custom DeveloperRole override. Full suite: **242 passing**.

## Test plan

- [ ] Build + security checks pass
- [ ] Sample runs; an authenticated Developer / system-key caller sees the full tool + resource list on `/mcp` (instead of an empty list)