### PR TITLE
fix(deps): pin Microsoft.AspNetCore.DataProtection >= 10.0.7 for net10.0

### DIFF
--- a/Tharga.Team.Blazor/Tharga.Team.Blazor.csproj
+++ b/Tharga.Team.Blazor/Tharga.Team.Blazor.csproj
@@ -20,7 +20,7 @@
     <InternalsVisibleTo>Tharga.Team.Blazor.Tests</InternalsVisibleTo>
   </PropertyGroup>
   <PropertyGroup>
-    <NoWarn>1701;1702;CS1591</NoWarn>
+    <NoWarn>1701;1702;CS1591;NU1510</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md">
@@ -35,6 +35,9 @@
     <PackageReference Include="Microsoft.Identity.Web" Version="4.8.0" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="Tharga.Blazor" Version="2.1.4" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Team\Tharga.Team.csproj" />


### PR DESCRIPTION
## Summary

Adds an explicit `PackageReference` for `Microsoft.AspNetCore.DataProtection` 10.0.7 in the `net10.0` conditional `ItemGroup` of `Tharga.Team.Blazor.csproj`.

Today the package flows in only transitively (via `Microsoft.Identity.Web` / the shared framework). The explicit reference declares a known-good `>= 10.0.7` floor in the consumer-facing `.nuspec`, so apps that consume `Tharga.Team.Blazor` get the dependency declaration even if the rest of their graph would resolve a lower version.

## Notes

- **NU1510 suppressed.** The package is part of the `Microsoft.AspNetCore.App` shared framework, so the SDK warns the local build prunes the explicit reference. The pin is for downstream consumer metadata, not for the build of this assembly itself.
- **net9.0 not pinned.** The request specified `>= 10.0.7` only. A 9.x floor can be added in a follow-up if needed.

## Tests

255 tests pass, 0 warnings.

## Test plan

- [ ] Build + security checks pass
- [ ] Verify the next published `Tharga.Team.Blazor` `.nupkg` lists `Microsoft.AspNetCore.DataProtection >= 10.0.7` under net10.0 dependencies