### PR TITLE
chore: bump Tharga.Blazor to 2.1.5 and Tharga.MongoDB to 2.10.10

### DIFF
--- a/Tharga.Team.Blazor/Tharga.Team.Blazor.csproj
+++ b/Tharga.Team.Blazor/Tharga.Team.Blazor.csproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Web" Version="4.9.0" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
-    <PackageReference Include="Tharga.Blazor" Version="2.1.4" />
+    <PackageReference Include="Tharga.Blazor" Version="2.1.5" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />

--- a/Tharga.Team.MongoDB/Tharga.Team.MongoDB.csproj
+++ b/Tharga.Team.MongoDB/Tharga.Team.MongoDB.csproj
@@ -28,7 +28,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Tharga.MongoDB" Version="2.10.9" />
+    <PackageReference Include="Tharga.MongoDB" Version="2.10.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Team\Tharga.Team.csproj" />

--- a/Tharga.Team.Service/Tharga.Team.Service.csproj
+++ b/Tharga.Team.Service/Tharga.Team.Service.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
-    <PackageReference Include="Tharga.MongoDB" Version="2.10.9" />
+    <PackageReference Include="Tharga.MongoDB" Version="2.10.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Team\Tharga.Team.csproj" />


### PR DESCRIPTION
## Summary

Routine NuGet package update.

- `Tharga.Blazor` 2.1.4 → 2.1.5 (`Tharga.Team.Blazor`) — picks up the new `CopyButton` `Size` parameter (`ButtonSize.ExtraSmall`/`Small`/`Medium`/`Large`) for inline use cases.
- `Tharga.MongoDB` 2.10.9 → 2.10.10 (`Tharga.Team.MongoDB`, `Tharga.Team.Service`).

No public API changes in this repo. Patch-level upgrades only.

## Test plan

- [x] `dotnet build -c Release` — clean, 0 warnings, 0 errors
- [x] `dotnet test -c Release` — 263 / 263 passing (37 Mcp + 139 Service + 87 Blazor)