### PR TITLE
fix: resilient member lookup in TeamComponent (#59)

### DIFF
--- a/Tharga.Team.Blazor.Tests/TeamMemberResolverTests.cs
+++ b/Tharga.Team.Blazor.Tests/TeamMemberResolverTests.cs
@@ -1,0 +1,123 @@
+using Microsoft.Extensions.Logging;
+using Tharga.Team;
+using Tharga.Team.Blazor.Features.Team;
+
+namespace Tharga.Team.Blazor.Tests;
+
+public class TeamMemberResolverTests
+{
+    [Fact]
+    public void Resolve_NoMatch_ReturnsNull()
+    {
+        var logger = new RecordingLogger();
+        var members = new[]
+        {
+            new FakeMember("a"),
+            new FakeMember("b")
+        };
+
+        var result = TeamMemberResolver.Resolve(members, m => m.Key == "x", logger, "team-1", "x");
+
+        Assert.Null(result);
+        Assert.Empty(logger.Warnings);
+    }
+
+    [Fact]
+    public void Resolve_SingleMatch_ReturnsIt_NoWarning()
+    {
+        var logger = new RecordingLogger();
+        var target = new FakeMember("b");
+        var members = new[]
+        {
+            new FakeMember("a"),
+            target,
+            new FakeMember("c")
+        };
+
+        var result = TeamMemberResolver.Resolve(members, m => m.Key == "b", logger, "team-1", "b");
+
+        Assert.Same(target, result);
+        Assert.Empty(logger.Warnings);
+    }
+
+    [Fact]
+    public void Resolve_TwoMatches_ReturnsFirst_LogsWarning()
+    {
+        var logger = new RecordingLogger();
+        var first = new FakeMember("dup");
+        var second = new FakeMember("dup");
+        var members = new[]
+        {
+            new FakeMember("a"),
+            first,
+            second
+        };
+
+        var result = TeamMemberResolver.Resolve(members, m => m.Key == "dup", logger, "team-42", "dup");
+
+        Assert.Same(first, result);
+        var warning = Assert.Single(logger.Warnings);
+        Assert.Contains("team-42", warning);
+        Assert.Contains("dup", warning);
+        Assert.Contains("2", warning);
+    }
+
+    [Fact]
+    public void Resolve_ThreeMatches_ReturnsFirst_LogsWarningWithCount()
+    {
+        var logger = new RecordingLogger();
+        var first = new FakeMember("dup");
+        var members = new[]
+        {
+            first,
+            new FakeMember("dup"),
+            new FakeMember("dup")
+        };
+
+        var result = TeamMemberResolver.Resolve(members, m => m.Key == "dup", logger, "team-7", "dup");
+
+        Assert.Same(first, result);
+        var warning = Assert.Single(logger.Warnings);
+        Assert.Contains("3", warning);
+    }
+
+    [Fact]
+    public void Resolve_NullLogger_DoesNotThrow_OnDuplicates()
+    {
+        var first = new FakeMember("dup");
+        var members = new[] { first, new FakeMember("dup") };
+
+        var result = TeamMemberResolver.Resolve(members, m => m.Key == "dup", logger: null, "team-1", "dup");
+
+        Assert.Same(first, result);
+    }
+
+    private sealed class FakeMember : ITeamMember
+    {
+        public FakeMember(string key) { Key = key; }
+        public string Key { get; }
+        public string Name => null;
+        public Invitation Invitation => null;
+        public DateTime? LastSeen => null;
+        public MembershipState? State => null;
+        public AccessLevel AccessLevel => AccessLevel.User;
+        public string[] TenantRoles => null;
+        public string[] ScopeOverrides => null;
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<string> Warnings { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state) => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+            {
+                Warnings.Add(formatter(state, exception));
+            }
+        }
+    }
+}

--- a/Tharga.Team.Blazor/Features/Team/TeamComponent.razor
+++ b/Tharga.Team.Blazor/Features/Team/TeamComponent.razor
@@ -1,5 +1,6 @@
 ﻿@using System.Text.Json
 @using Microsoft.Extensions.DependencyInjection
+@using Microsoft.Extensions.Logging
 @using Microsoft.Extensions.Options
 @using Microsoft.JSInterop
 @using Tharga.Team
@@ -17,6 +18,7 @@
 @inject NotificationService NotificationService
 @inject IOptions<ThargaBlazorOptions> BlazorOptions
 @inject IServiceProvider ServiceProvider
+@inject ILogger<TeamComponent<TMember>> Logger
 
 @if (_teams == null)
 {
@@ -313,7 +315,13 @@ else
     private async Task ChangeTenantRoles(ITeam<TMember> team, string userKey, IEnumerable<string> roles)
     {
         var user = _users.FirstOrDefault(x => x.Key == userKey || x.Identity == userKey);
-        var member = team.Members.Single(x => x.Key == (user?.Key ?? userKey));
+        var lookupKey = user?.Key ?? userKey;
+        var member = TeamMemberResolver.Resolve(team.Members, x => x.Key == lookupKey, Logger, team.Key, lookupKey);
+        if (member == null)
+        {
+            NotifyMemberNotFound();
+            return;
+        }
 
         await TeamManagementService.SetMemberTenantRolesAsync(team.Key, member.Key, roles.ToArray());
         await ReloadTeams();
@@ -322,7 +330,13 @@ else
     private async Task ChangeScopeOverrides(ITeam<TMember> team, string userKey, IEnumerable<string> scopes)
     {
         var user = _users.FirstOrDefault(x => x.Key == userKey || x.Identity == userKey);
-        var member = team.Members.Single(x => x.Key == (user?.Key ?? userKey));
+        var lookupKey = user?.Key ?? userKey;
+        var member = TeamMemberResolver.Resolve(team.Members, x => x.Key == lookupKey, Logger, team.Key, lookupKey);
+        if (member == null)
+        {
+            NotifyMemberNotFound();
+            return;
+        }
 
         await TeamManagementService.SetMemberScopeOverridesAsync(team.Key, member.Key, scopes.ToArray());
         await ReloadTeams();
@@ -391,7 +405,14 @@ else
     private async Task RemoveUserFromTeam(ITeam<TMember> team, string userKey)
     {
         var user = _users.FirstOrDefault(x => x.Key == userKey || x.Identity == userKey);
-        var member = team.Members.Single(x => x.Key == (user?.Key ?? userKey));
+        var lookupKey = user?.Key ?? userKey;
+        var member = TeamMemberResolver.Resolve(team.Members, x => x.Key == lookupKey, Logger, team.Key, lookupKey);
+        if (member == null)
+        {
+            NotifyMemberNotFound();
+            return;
+        }
+
         var email = member.Invitation?.EMail ?? user?.EMail;
         var response = await DialogService.Confirm($"User '{email}' will be removed from the team '{team.Name}'.");
         if (response != true) return;
@@ -403,10 +424,21 @@ else
     private async Task ChangeRole(ITeam<TMember> team, string userKey, AccessLevel accessLevel)
     {
         var user = _users.FirstOrDefault(x => x.Key == userKey || x.Identity == userKey);
-        var member = team.Members.Single(x => x.Key == (user?.Key ?? userKey));
+        var lookupKey = user?.Key ?? userKey;
+        var member = TeamMemberResolver.Resolve(team.Members, x => x.Key == lookupKey, Logger, team.Key, lookupKey);
+        if (member == null)
+        {
+            NotifyMemberNotFound();
+            return;
+        }
 
         await TeamManagementService.SetMemberRoleAsync(team.Key, member.Key, accessLevel);
         await ReloadTeams();
+    }
+
+    private void NotifyMemberNotFound()
+    {
+        NotificationService.Notify(NotificationSeverity.Warning, "Member not found", "The member could not be located. Please reload the page.");
     }
 
     private void StartMemberNameEdit(TMember member)
@@ -532,7 +564,8 @@ else
 
     private bool HasAccessLevel(ITeam<TMember> team, AccessLevel accessLevel)
     {
-        var member = team.Members.Single(x => x.Key == _user.Key);
+        var member = TeamMemberResolver.Resolve(team.Members, x => x.Key == _user.Key, Logger, team.Key, _user.Key);
+        if (member == null) return false;
         return member.AccessLevel <= accessLevel;
     }
 

--- a/Tharga.Team.Blazor/Features/Team/TeamMemberResolver.cs
+++ b/Tharga.Team.Blazor/Features/Team/TeamMemberResolver.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace Tharga.Team.Blazor.Features.Team;
+
+internal static class TeamMemberResolver
+{
+    public static TMember Resolve<TMember>(
+        IEnumerable<TMember> members,
+        Func<TMember, bool> predicate,
+        ILogger logger,
+        string teamKey,
+        string lookupKey)
+        where TMember : class, ITeamMember
+    {
+        var matches = members.Where(predicate).ToArray();
+
+        if (matches.Length == 0) return null;
+        if (matches.Length == 1) return matches[0];
+
+        logger?.LogWarning(
+            "Duplicate TeamMember rows for team {TeamKey} key {LookupKey}: found {Count}. Using first; clean up duplicates.",
+            teamKey, lookupKey, matches.Length);
+
+        return matches[0];
+    }
+}

--- a/plan/feature.md
+++ b/plan/feature.md
@@ -1,0 +1,51 @@
+# Feature: TeamMember duplicate-row resilience in TeamComponent
+
+GitHub issue: [Tharga/Platform#59](https://github.com/Tharga/Platform/issues/59)
+
+## Problem
+
+When a `Team.Members` collection contains two or more rows matching the same predicate (typically same `Key` from a migration glitch or missing unique constraint), every `.Single(predicate)` call site in `TeamComponent<T>` throws `InvalidOperationException: Sequence contains more than one matching element`. The exception bricks the team-management page until reload — observed 5x in 24h on Quilt4Net.Server prod (consumer of `Tharga.Team.Blazor` 2.0.16).
+
+## Goal
+
+Make `TeamComponent<T>` resilient to duplicate `TeamMember` rows. The page must remain usable; duplicates are surfaced via warning logs so operators can clean them up.
+
+## Scope
+
+In-scope (5 call sites in [TeamComponent.razor](../Tharga.Team.Blazor/Features/Team/TeamComponent.razor)):
+
+1. `RemoveUserFromTeam` (line 394) — the call site in the issue.
+2. `ChangeRole` (line 406).
+3. `ChangeTenantRoles` (line 316).
+4. `ChangeScopeOverrides` (line 325).
+5. `HasAccessLevel` (line 535) — runs every render; highest crash exposure.
+
+Out of scope:
+- Repository-layer unique index on `(TeamKey, UserKey)` — separate change, needs migration plan for existing duplicates.
+- Self-healing delete-on-read — couples a read handler to a destructive write; risk too high for this fix.
+- Other `.Single(...)` usages outside `TeamComponent.razor`.
+
+## Approach
+
+1. Inject `ILogger<TeamComponent<TMember>>` into the component.
+2. Extract a small helper `ResolveMember(IEnumerable<TMember> members, string key, ILogger logger, string teamKey)` that:
+   - Materializes matches once.
+   - Returns `null` if none found.
+   - Returns the first match if exactly one.
+   - Logs a warning with team key + member key + match count if more than one, then returns the first match.
+3. Replace all 5 `.Single(predicate)` sites with the helper.
+4. Each call site handles a `null` return defensively (member already gone — no-op or graceful UI message).
+5. Unit-test the helper against the four cases (none, one, two-or-more, null inputs).
+
+## Acceptance criteria
+
+- All 5 call sites use the new helper instead of `.Single(...)`.
+- A team with duplicate member rows no longer crashes the page on any of the 5 actions.
+- Warning log emitted (with team key + member key + count) when duplicates are encountered.
+- New unit tests cover: no match, single match, two matches (warning logged + first returned), three matches.
+- Existing tests still pass: `dotnet build -c Release && dotnet test -c Release`.
+- README/docs unchanged (internal resilience fix; no public API change beyond a new helper that may stay `internal`).
+
+## Done condition
+
+User confirms the fix works against a reproduction (or against the production data that produced the original error).

--- a/plan/plan.md
+++ b/plan/plan.md
@@ -1,0 +1,31 @@
+# Plan: TeamMember duplicate-row resilience
+
+Branch: `feature/teammember-duplicate-fix` (created from `master`).
+
+## Steps
+
+- [x] **1. Confirm plan with user.** Done.
+- [x] **2. Add the resolver helper.** `Tharga.Team.Blazor/Features/Team/TeamMemberResolver.cs` — internal static `Resolve<TMember>(...)` per spec.
+- [x] **3. Add unit tests.** `Tharga.Team.Blazor.Tests/TeamMemberResolverTests.cs` — 5 tests (no match, single, two, three, null logger). All passing.
+- [x] **4. Wire logger into TeamComponent.** `@inject ILogger<TeamComponent<TMember>> Logger` + `Microsoft.Extensions.Logging` `@using` added.
+- [x] **5. Replace `.Single(...)` call sites.** All 5 sites in `TeamComponent.razor` converted. Action handlers fall through `NotifyMemberNotFound()` (extracted to avoid repeating the Radzen notify 4×); `HasAccessLevel` returns `false` on null.
+- [x] **6. Build and run tests.** Build clean (0 warnings, 0 errors). All 268 tests passing (37 + 139 + 92 — was 263 + 5 new resolver tests).
+- [~] **7. Manual sanity check.** Cannot reproduce duplicate-row scenario locally without seeded data. Resolver covered by unit tests; happy paths exercised by existing component tests.
+- [x] **8. Commit.** Single commit including `plan/`. Two side-bugs filed to `Requests.md` instead of bundled here: (a) NRE on unauthenticated `GetTeamsAsync`, (b) inline name-edit broken for invited members (null `Member.Key`).
+- [ ] **9. Hand back to user for testing.**
+- [ ] **10. (After user OK) Open PR.** Push and open PR against `master`. PR description = release notes.
+- [ ] **11. (After PR merged) Close out.** Archive `plan/feature.md` to `$DOC_ROOT/Tharga/plans/Toolkit/Platform/done/teammember-duplicate-fix.md`, delete `plan/`, final commit `feat: teammember-duplicate-fix complete`.
+
+## Notes
+
+- The `Tharga.MongoDB 2.10.9 → 2.10.10` and `Tharga.Blazor 2.1.4 → 2.1.5` upgrades shipped separately on `feature/upgrade-tharga-packages` (PR #60, merged before this branch was rebased).
+- No README change planned — fix is internal resilience.
+- A repository-layer unique index would prevent future duplicates but is explicitly out of scope (see `feature.md`).
+
+## Last session (2026-05-10)
+
+- Upgrades landed first via PR #60 (`Tharga.Blazor` → 2.1.5, `Tharga.MongoDB` → 2.10.10).
+- This branch rebased on the new master; steps 2–6 executed in one pass.
+- Bonus: helper handles `logger == null` defensively (covered by a 5th unit test).
+- `NotifyMemberNotFound()` extracted to share between the 4 action handlers.
+- Pending user sign-off before commit / push / PR.


### PR DESCRIPTION
## Summary

Fixes [#59](https://github.com/Tharga/Platform/issues/59).

`<TeamComponent />` no longer crashes the team-management page when a team document carries duplicate `TeamMember` rows for the same `Key` (e.g. from a migration glitch or missing unique constraint). Five member-lookup sites in `TeamComponent.razor` previously used `.Single(predicate)`, which threw `InvalidOperationException` on duplicates and bricked the page until reload — once tripped, every subsequent click on a different row also threw.

- `RemoveUserFromTeam`, `ChangeRole`, `ChangeTenantRoles`, `ChangeScopeOverrides`, `HasAccessLevel` all now go through a new `TeamMemberResolver.Resolve(...)` helper.
- Helper returns the first match, returns `null` when no match, and logs a warning (with team key, lookup key, count) when duplicates are found — so operators can find and clean up the bad rows.
- Action handlers gracefully notify the user (`"Member not found — please reload"`) and bail without throwing if the member has disappeared between renders. `HasAccessLevel` returns `false` defensively.

The repository layer is unchanged in this PR — duplicates remain operator-cleanup. Adding a unique index on `(TeamKey, UserKey)` to prevent duplicates going forward is tracked separately.

## Consumer impact

- No public API change. The fix is internal resilience.
- Consumers that have observed `Sequence contains more than one matching element` from `TeamComponent` should pick this up on next package upgrade — the page will stay usable, and a warning will appear in logs identifying the duplicate.

## Test plan

- [x] 5 new unit tests in `TeamMemberResolverTests` cover no-match (returns null), single match (returns it), 2 / 3 matches (returns first + logs warning with count), and null logger (does not throw).
- [x] `dotnet build -c Release` — clean, 0 warnings, 0 errors.
- [x] `dotnet test -c Release` — 268 / 268 passing (was 263, +5 new).
- [ ] Production verification on consumer hitting the duplicate-row scenario (no local repro available — operator will confirm).