### PR TITLE
feat: accept Authorization: Bearer in API key authentication

### DIFF
--- a/Tharga.Team.Service.Tests/ApiKeyAuthenticationHandlerTests.cs
+++ b/Tharga.Team.Service.Tests/ApiKeyAuthenticationHandlerTests.cs
@@ -33,12 +33,16 @@ public class ApiKeyAuthenticationHandlerTests
         return handler;
     }
 
-    private static HttpContext CreateHttpContext(string apiKeyHeaderValue = null)
+    private static HttpContext CreateHttpContext(string apiKeyHeaderValue = null, string authorizationHeaderValue = null)
     {
         var context = new DefaultHttpContext();
         if (apiKeyHeaderValue != null)
         {
             context.Request.Headers[ApiKeyConstants.HeaderName] = apiKeyHeaderValue;
+        }
+        if (authorizationHeaderValue != null)
+        {
+            context.Request.Headers["Authorization"] = authorizationHeaderValue;
         }
         return context;
     }
@@ -157,6 +161,97 @@ public class ApiKeyAuthenticationHandlerTests
         var accessLevelClaim = result.Principal.FindFirst(TeamClaimTypes.AccessLevel);
         Assert.NotNull(accessLevelClaim);
         Assert.Equal("Viewer", accessLevelClaim.Value);
+    }
+
+    [Fact]
+    public async Task With_Bearer_Token_Returns_Success_With_Claims()
+    {
+        var apiKey = CreateApiKey("team-bearer");
+        _apiKeyService.GetByApiKeyAsync("bearer-key").Returns(Task.FromResult(apiKey));
+
+        var context = CreateHttpContext(authorizationHeaderValue: "Bearer bearer-key");
+        var handler = await CreateHandler(context);
+
+        var result = await handler.AuthenticateAsync();
+
+        Assert.True(result.Succeeded);
+        var teamKeyClaim = result.Principal.FindFirst(TeamClaimTypes.TeamKey);
+        Assert.NotNull(teamKeyClaim);
+        Assert.Equal("team-bearer", teamKeyClaim.Value);
+    }
+
+    [Fact]
+    public async Task With_Bearer_Token_Lowercase_Scheme_Returns_Success()
+    {
+        var apiKey = CreateApiKey("team-lower");
+        _apiKeyService.GetByApiKeyAsync("lower-key").Returns(Task.FromResult(apiKey));
+
+        var context = CreateHttpContext(authorizationHeaderValue: "bearer lower-key");
+        var handler = await CreateHandler(context);
+
+        var result = await handler.AuthenticateAsync();
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task With_Bearer_And_XApiKey_Bearer_Takes_Precedence()
+    {
+        var bearerKey = CreateApiKey("team-bearer-wins");
+        _apiKeyService.GetByApiKeyAsync("bearer-token").Returns(Task.FromResult(bearerKey));
+        _apiKeyService.GetByApiKeyAsync("xapikey-token").Returns(Task.FromResult<IApiKey>(null));
+
+        var context = CreateHttpContext(
+            apiKeyHeaderValue: "xapikey-token",
+            authorizationHeaderValue: "Bearer bearer-token");
+        var handler = await CreateHandler(context);
+
+        var result = await handler.AuthenticateAsync();
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("team-bearer-wins", result.Principal.FindFirst(TeamClaimTypes.TeamKey)?.Value);
+    }
+
+    [Fact]
+    public async Task With_Non_Bearer_Authorization_Falls_Back_To_XApiKey()
+    {
+        var apiKey = CreateApiKey("team-fallback");
+        _apiKeyService.GetByApiKeyAsync("xapi-fallback").Returns(Task.FromResult(apiKey));
+
+        // Basic auth (or anything not "Bearer ") should be ignored; X-API-KEY remains the source.
+        var context = CreateHttpContext(
+            apiKeyHeaderValue: "xapi-fallback",
+            authorizationHeaderValue: "Basic some-other-credential");
+        var handler = await CreateHandler(context);
+
+        var result = await handler.AuthenticateAsync();
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("team-fallback", result.Principal.FindFirst(TeamClaimTypes.TeamKey)?.Value);
+    }
+
+    [Fact]
+    public async Task With_Only_Non_Bearer_Authorization_Returns_NoResult()
+    {
+        var context = CreateHttpContext(authorizationHeaderValue: "Basic abc");
+        var handler = await CreateHandler(context);
+
+        var result = await handler.AuthenticateAsync();
+
+        Assert.False(result.Succeeded);
+        Assert.True(result.None);
+    }
+
+    [Fact]
+    public async Task With_Empty_Bearer_Token_Returns_NoResult()
+    {
+        var context = CreateHttpContext(authorizationHeaderValue: "Bearer ");
+        var handler = await CreateHandler(context);
+
+        var result = await handler.AuthenticateAsync();
+
+        Assert.False(result.Succeeded);
+        Assert.True(result.None);
     }
 
     [Fact]

--- a/Tharga.Team.Service/ApiKeyAuthenticationHandler.cs
+++ b/Tharga.Team.Service/ApiKeyAuthenticationHandler.cs
@@ -36,10 +36,21 @@ public class ApiKeyAuthenticationHandler : AuthenticationHandler<AuthenticationS
 
     protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        if (!Request.Headers.TryGetValue(ApiKeyConstants.HeaderName, out var apiKeyHeader))
-            return AuthenticateResult.NoResult();
+        // Prefer Authorization: Bearer (MCP convention; the only header most MCP clients can send).
+        // Fall back to X-API-KEY so existing callers keep working.
+        string apiKey = null;
 
-        var apiKey = apiKeyHeader.ToString();
+        if (Request.Headers.TryGetValue("Authorization", out var authHeader))
+        {
+            var auth = authHeader.ToString();
+            if (auth.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                apiKey = auth["Bearer ".Length..].Trim();
+        }
+
+        if (string.IsNullOrWhiteSpace(apiKey)
+            && Request.Headers.TryGetValue(ApiKeyConstants.HeaderName, out var apiKeyHeader))
+            apiKey = apiKeyHeader.ToString().Trim();
+
         if (string.IsNullOrWhiteSpace(apiKey))
             return AuthenticateResult.NoResult();
 


### PR DESCRIPTION
## What's new

`ApiKeyAuthenticationHandler` now accepts `Authorization: Bearer <token>` in addition to the existing `X-API-KEY` header. Both authentication paths produce the same principal and claims — pick whichever the client can send.

### Why

MCP clients — including Anthropic's hosted `mcp_servers` proxy used by Mimir/Neurolita — can only send `Authorization: Bearer`. They have no way to set custom headers like `X-API-KEY`. Without Bearer support, those clients cannot authenticate against any endpoint protected by `AddThargaApiKeyAuthentication`.

### Behaviour

| Request | Result |
|---|---|
| `Authorization: Bearer <token>` | Authenticates with `<token>` |
| `Authorization: bearer <token>` | Same — scheme match is case-insensitive |
| `Authorization: Bearer <token>` **and** `X-API-KEY: <other>` | Bearer wins |
| `Authorization: Basic ...` **and** `X-API-KEY: <token>` | Non-Bearer ignored; X-API-KEY authenticates |
| `Authorization: Basic ...` alone | `NoResult()` — falls through to next handler |
| `Authorization: Bearer ` (empty token) | `NoResult()` |
| `X-API-KEY: <token>` only | Authenticates (unchanged) |

No source-level changes for consumers — downstream packages (`Tharga.Team.Blazor`, `Tharga.Platform.Mcp`, `Tharga.Mcp` via host scheme registration) and host apps pick up Bearer support automatically with a Platform 2.1.x package bump.

## Test plan

- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `dotnet test -c Release` — 318/318 pass (163 in `Tharga.Team.Service.Tests`, +6 new covering Bearer-only, lowercase scheme, Bearer+X-API-KEY precedence, non-Bearer fallback, non-Bearer alone, empty Bearer token)