### PR TITLE
feat: ApiKeyView scope-overrides UI + SetScopeOverridesAsync service API

### DIFF
--- a/Tharga.Team.Blazor.Tests/ApiKeyViewScopeOverridesTests.cs
+++ b/Tharga.Team.Blazor.Tests/ApiKeyViewScopeOverridesTests.cs
@@ -1,0 +1,45 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Components;
+
+namespace Tharga.Team.Blazor.Tests;
+
+/// <summary>
+/// Smoke tests for the <c>ApiKeyView.ShowScopeOverrides</c> parameter added under
+/// <see href="https://github.com/Tharga/Platform/issues/71">Tharga/Platform#71</see>.
+/// </summary>
+public class ApiKeyViewScopeOverridesTests
+{
+    [Fact]
+    public void ApiKeyView_HasShowScopeOverridesParameter_DefaultFalse()
+    {
+        var componentType = ResolveApiKeyView();
+        var prop = componentType.GetProperty("ShowScopeOverrides");
+
+        Assert.NotNull(prop);
+        Assert.Equal(typeof(bool), prop.PropertyType);
+        Assert.NotNull(prop.GetCustomAttribute<ParameterAttribute>());
+
+        var instance = Activator.CreateInstance(componentType);
+        Assert.False((bool)prop.GetValue(instance));
+    }
+
+    [Fact]
+    public void ApiKeyView_StillHasShowAuditLogButtonParameter()
+    {
+        // Regression guard — adding ShowScopeOverrides must not have displaced the existing parameter.
+        var componentType = ResolveApiKeyView();
+        var prop = componentType.GetProperty("ShowAuditLogButton");
+
+        Assert.NotNull(prop);
+        Assert.Equal(typeof(bool), prop.PropertyType);
+        Assert.NotNull(prop.GetCustomAttribute<ParameterAttribute>());
+    }
+
+    private static Type ResolveApiKeyView()
+    {
+        var blazorAssembly = typeof(Tharga.Team.Blazor.Framework.ThargaBlazorRegistration).Assembly;
+        return blazorAssembly
+            .GetTypes()
+            .Single(t => t.Namespace == "Tharga.Team.Blazor.Features.Api" && t.Name == "ApiKeyView");
+    }
+}

--- a/Tharga.Team.Blazor/Features/Api/ApiKeyView.razor
+++ b/Tharga.Team.Blazor/Features/Api/ApiKeyView.razor
@@ -70,6 +70,14 @@ else
                     </Template>
                 </RadzenDataGridColumn>
             }
+            @if (_options.AdvancedMode && _scopeRegistry != null && ShowScopeOverrides)
+            {
+                <RadzenDataGridColumn Title="Scopes" Width="180px">
+                    <Template>
+                        @string.Join(", ", context.ScopeOverrides ?? Array.Empty<string>())
+                    </Template>
+                </RadzenDataGridColumn>
+            }
             @if (_options.AdvancedMode && _scopeRegistry != null)
             {
                 <RadzenDataGridColumn Title="" Width="40px">
@@ -86,6 +94,7 @@ else
                     <RadzenButton Icon="visibility_off" Click="@(_ => context.VisibleKey = _apiKeyMask)" Visible="@(!string.IsNullOrEmpty(context.ApiKey) && context.VisibleKey != _apiKeyMask)" />
                     <RadzenButton Icon="content_copy" Click="@(_ => CopyToClipboard(context))" Visible="@(!string.IsNullOrEmpty(context.ApiKey))" />
                     <RadzenButton Icon="manage_search" Click="@(_ => OpenAuditLogAsync(context))" Visible="@ShowAuditLogButton" title="View audit log for this key" />
+                    <RadzenButton Icon="tune" Click="@(_ => OpenEditScopesAsync(context))" Visible="@(ShowScopeOverrides && _scopeRegistry != null)" title="Edit scope overrides" />
                     <RadzenButton Icon="lock" Click="@(_ => LockKeyAsync(context))" Visible="@(!string.IsNullOrEmpty(context.ApiKey))" />
                     <RadzenButton Icon="refresh" Click="@(_ => RefreshAsync(context))" />
                     <RadzenButton Icon="delete" ButtonStyle="ButtonStyle.Danger" Variant="Variant.Flat" Click="@(_ => DeleteAsync(context))" Visible="@(_options.AdvancedMode)" />
@@ -113,6 +122,20 @@ else
                                       Min="@DateTime.UtcNow.Date"
                                       Max="@(_options.MaxExpiryDays.HasValue ? DateTime.UtcNow.AddDays(_options.MaxExpiryDays.Value).Date : DateTime.MaxValue)" />
                 </RadzenStack>
+                @if (ShowScopeOverrides && _scopeRegistry != null)
+                {
+                    <RadzenStack Gap="0.25rem">
+                        <RadzenLabel Text="Scopes" />
+                        <RadzenDropDown TValue="IEnumerable<string>"
+                                        Multiple="true"
+                                        Chips="true"
+                                        AllowClear="true"
+                                        Value="@_newScopeOverrides"
+                                        ValueChanged="@(v => _newScopeOverrides = (v ?? Enumerable.Empty<string>()).ToList())"
+                                        Data="@_scopeRegistry.All.Select(s => s.Name)"
+                                        Style="min-width: 200px;" />
+                    </RadzenStack>
+                }
                 <RadzenButton Text="Create" Icon="add" Click="@CreateAsync"
                               Disabled="@string.IsNullOrWhiteSpace(_newName)" />
             </RadzenStack>
@@ -130,6 +153,14 @@ else
     /// </summary>
     [Parameter] public bool ShowAuditLogButton { get; set; }
 
+    /// <summary>
+    /// When true (and an <see cref="IScopeRegistry"/> is registered), surfaces per-key <c>ScopeOverrides</c>:
+    /// a new column shows current overrides, the create card gets a multi-select, and each row gets an
+    /// Edit-Scopes icon button that opens a dialog. Default false — opt in on pages where operators
+    /// should manage narrow-scope keys (e.g. Quilt4Net.Server Value Group keys).
+    /// </summary>
+    [Parameter] public bool ShowScopeOverrides { get; set; }
+
     private bool _apiKeyServiceMissing;
     private IApiKeyManagementService _apiKeyManagementService;
     private bool _hasAccess;
@@ -144,6 +175,7 @@ else
     private string _newName = "";
     private AccessLevel _newAccessLevel = AccessLevel.User;
     private DateTime? _newExpiryDate;
+    private List<string> _newScopeOverrides = new();
 
     protected override async Task OnInitializedAsync()
     {
@@ -201,12 +233,14 @@ else
     {
         try
         {
-            var created = await _apiKeyManagementService.CreateKeyAsync(_selectedTeam.Key, _newName, _newAccessLevel, null, _newExpiryDate);
+            var scopes = _newScopeOverrides.Count > 0 ? _newScopeOverrides.ToArray() : null;
+            var created = await _apiKeyManagementService.CreateKeyAsync(_selectedTeam.Key, _newName, _newAccessLevel, roles: null, scopeOverrides: scopes, expiryDate: _newExpiryDate);
             _newName = "";
             _newAccessLevel = AccessLevel.User;
             _newExpiryDate = _options.MaxExpiryDays.HasValue
                 ? DateTime.UtcNow.AddDays(_options.MaxExpiryDays.Value).Date
                 : null;
+            _newScopeOverrides = new List<string>();
             await ReloadData();
             ShowKeyOnce(created);
             NotificationService.Notify(NotificationSeverity.Success, "API key created");
@@ -311,13 +345,55 @@ else
             new DialogOptions { Width = "90vw", Height = "85vh", Resizable = true, Draggable = true });
     }
 
+    private async Task OpenEditScopesAsync(ApiKeyModel context)
+    {
+        if (_scopeRegistry == null) return;
+
+        var selected = (context.ScopeOverrides ?? Array.Empty<string>()).ToList();
+        var scopeOptions = _scopeRegistry.All.Select(s => s.Name).ToArray();
+
+        await DialogService.OpenAsync($"Edit Scopes — {context.Name}", ds =>
+            @<RadzenStack Gap="1rem" Style="padding: 1rem; min-width: 400px;">
+                <RadzenLabel Text="Scope Overrides" />
+                <RadzenDropDown TValue="IEnumerable<string>"
+                                Multiple="true"
+                                Chips="true"
+                                AllowClear="true"
+                                Value="@selected"
+                                ValueChanged="@(v => selected = (v ?? Enumerable.Empty<string>()).ToList())"
+                                Data="@scopeOptions"
+                                Style="width: 100%;" />
+                <RadzenStack Orientation="Orientation.Horizontal" JustifyContent="JustifyContent.End" Gap="0.5rem">
+                    <RadzenButton Text="Cancel" ButtonStyle="ButtonStyle.Light" Click="@(() => ds.Close())" />
+                    <RadzenButton Text="Save" ButtonStyle="ButtonStyle.Primary"
+                                  Click="@(async () => { await SaveScopeOverridesAsync(context, selected.ToArray()); ds.Close(); })" />
+                </RadzenStack>
+            </RadzenStack>,
+            new DialogOptions { ShowClose = false });
+    }
+
+    private async Task SaveScopeOverridesAsync(ApiKeyModel context, string[] scopes)
+    {
+        try
+        {
+            await _apiKeyManagementService.SetScopeOverridesAsync(_selectedTeam.Key, context.Key, scopes);
+            await ReloadData();
+            NotificationService.Notify(NotificationSeverity.Success, "Scope overrides updated");
+        }
+        catch (Exception ex)
+        {
+            NotificationService.Notify(NotificationSeverity.Error, "Failed to update scopes", ex.Message);
+        }
+    }
+
     private string GetActionsColumnWidth()
     {
         // Base 180px (matches the original simple-mode width), +40 for delete in advanced mode,
-        // +40 when the audit log button is shown.
+        // +40 when the audit log button is shown, +40 when the edit-scopes button is shown.
         var width = 180;
         if (_options?.AdvancedMode == true) width += 40;
         if (ShowAuditLogButton) width += 40;
+        if (ShowScopeOverrides && _scopeRegistry != null) width += 40;
         return $"{width}px";
     }
 }

--- a/Tharga.Team.Blazor/README.md
+++ b/Tharga.Team.Blazor/README.md
@@ -8,7 +8,7 @@ Team management Blazor components for multi-tenant applications. Works with both
 ## Components
 
 - **Team management** - `TeamSelector`, `TeamComponent`, `TeamDialog`, `InviteUserDialog`, `TeamInviteView`.
-- **API key management** - `ApiKeyView` for team-scoped API keys.
+- **API key management** - `ApiKeyView` for team-scoped API keys. Opt-in parameters: `ShowAuditLogButton` (per-row audit-log dialog), `ShowScopeOverrides` (Scopes column + create-card multi-select + Edit-Scopes dialog per row).
 - **User management** - `UserProfileView`, `UsersView`.
 - **Authentication** - `LoginDisplay` with login/logout and team navigation.
 - **Claims augmentation** - `TeamClaimsAuthenticationStateProvider` adds `TeamKey`, `AccessLevel`, role, and scope claims. Compatible with all hosting models.

--- a/Tharga.Team.Service.Tests/ApiKeyAdministrationServiceTests.cs
+++ b/Tharga.Team.Service.Tests/ApiKeyAdministrationServiceTests.cs
@@ -138,6 +138,72 @@ public class ApiKeyAdministrationServiceTests
         await Assert.ThrowsAsync<UnauthorizedAccessException>(() => _sut.DeleteKeyAsync("team-2", "key-1"));
     }
 
+    [Fact]
+    public async Task SetScopeOverridesAsync_Updates_Entity()
+    {
+        var entity = CreateEntity("key-1", "hash-1", "team-1");
+        _repository.GetAsync("key-1").Returns(Task.FromResult(entity));
+
+        await _sut.SetScopeOverridesAsync("team-1", "key-1", new[] { "valuegroup:read", "valuegroup:write" });
+
+        await _repository.Received(1).UpdateAsync("key-1", Arg.Is<ApiKeyEntity>(e =>
+            e.ScopeOverrides != null
+            && e.ScopeOverrides.Length == 2
+            && e.ScopeOverrides[0] == "valuegroup:read"
+            && e.ScopeOverrides[1] == "valuegroup:write"));
+    }
+
+    [Fact]
+    public async Task SetScopeOverridesAsync_EmptyArray_ClearsOverridesToNull()
+    {
+        var entity = CreateEntity("key-1", "hash-1", "team-1") with { ScopeOverrides = new[] { "stale:scope" } };
+        _repository.GetAsync("key-1").Returns(Task.FromResult(entity));
+
+        await _sut.SetScopeOverridesAsync("team-1", "key-1", Array.Empty<string>());
+
+        await _repository.Received(1).UpdateAsync("key-1", Arg.Is<ApiKeyEntity>(e => e.ScopeOverrides == null));
+    }
+
+    [Fact]
+    public async Task SetScopeOverridesAsync_WrongTeam_Throws()
+    {
+        var entity = CreateEntity("key-1", "hash-1", "team-1");
+        _repository.GetAsync("key-1").Returns(Task.FromResult(entity));
+
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+            _sut.SetScopeOverridesAsync("team-2", "key-1", new[] { "x" }));
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<string>(), Arg.Any<ApiKeyEntity>());
+    }
+
+    [Fact]
+    public async Task CreateKeyAsync_With_ScopeOverrides_Sets_Field_On_Entity()
+    {
+        _apiKeyService.BuildApiKey(Arg.Any<string>(), Arg.Any<Func<string>>()).Returns("new-key");
+        _apiKeyService.Encrypt("new-key").Returns("new-hash");
+        _repository.AddAsync(Arg.Any<ApiKeyEntity>()).Returns(ci => Task.FromResult(ci.Arg<ApiKeyEntity>()));
+
+        var scopes = new[] { "doc:read", "doc:write" };
+        await _sut.CreateKeyAsync("team-1", "My Key", AccessLevel.User, roles: null, scopeOverrides: scopes);
+
+        await _repository.Received(1).AddAsync(Arg.Is<ApiKeyEntity>(e =>
+            e.ScopeOverrides != null
+            && e.ScopeOverrides.Length == 2
+            && e.ScopeOverrides[0] == "doc:read"
+            && e.ScopeOverrides[1] == "doc:write"));
+    }
+
+    [Fact]
+    public async Task CreateKeyAsync_Without_ScopeOverrides_LeavesFieldNull()
+    {
+        _apiKeyService.BuildApiKey(Arg.Any<string>(), Arg.Any<Func<string>>()).Returns("new-key");
+        _apiKeyService.Encrypt("new-key").Returns("new-hash");
+        _repository.AddAsync(Arg.Any<ApiKeyEntity>()).Returns(ci => Task.FromResult(ci.Arg<ApiKeyEntity>()));
+
+        await _sut.CreateKeyAsync("team-1", "My Key", AccessLevel.User);
+
+        await _repository.Received(1).AddAsync(Arg.Is<ApiKeyEntity>(e => e.ScopeOverrides == null));
+    }
+
     private static ApiKeyEntity CreateEntity(string key, string hash, string teamKey)
     {
         return new ApiKeyEntity

--- a/Tharga.Team.Service.Tests/AuditingApiKeyServiceDecoratorTests.cs
+++ b/Tharga.Team.Service.Tests/AuditingApiKeyServiceDecoratorTests.cs
@@ -12,7 +12,7 @@ public class AuditingApiKeyServiceDecoratorTests
     public AuditingApiKeyServiceDecoratorTests()
     {
         _inner = Substitute.For<IApiKeyAdministrationService>();
-        _inner.CreateKeyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AccessLevel>(), Arg.Any<string[]>(), Arg.Any<DateTime?>())
+        _inner.CreateKeyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AccessLevel>(), Arg.Any<string[]>(), Arg.Any<string[]>(), Arg.Any<DateTime?>())
             .Returns(Substitute.For<IApiKey>());
         _inner.RefreshKeyAsync(Arg.Any<string>(), Arg.Any<string>())
             .Returns(Substitute.For<IApiKey>());

--- a/Tharga.Team.Service/ApiKeyAdministrationService.cs
+++ b/Tharga.Team.Service/ApiKeyAdministrationService.cs
@@ -71,7 +71,7 @@ public class ApiKeyAdministrationService : IApiKeyAdministrationService
         {
             var name = IntegerExtensions.GetNameForNumber(i + 1);
             var expiryDate = GetDefaultExpiryDate();
-            var entity = BuildKey(teamKey, name, [], AccessLevel.User, null, expiryDate);
+            var entity = BuildKey(teamKey, name, [], AccessLevel.User, null, null, expiryDate);
             var created = await _repository.AddAsync(entity);
 
             if (_options.AutoLockKeys)
@@ -85,7 +85,7 @@ public class ApiKeyAdministrationService : IApiKeyAdministrationService
     }
 
     /// <inheritdoc />
-    public async Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, DateTime? expiryDate = null)
+    public async Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null)
     {
         expiryDate ??= GetDefaultExpiryDate();
 
@@ -96,7 +96,7 @@ public class ApiKeyAdministrationService : IApiKeyAdministrationService
                 throw new InvalidOperationException($"Expiry date cannot exceed {_options.MaxExpiryDays} days from now.");
         }
 
-        var entity = BuildKey(teamKey, name, new Dictionary<string, string>(), accessLevel, roles, expiryDate);
+        var entity = BuildKey(teamKey, name, new Dictionary<string, string>(), accessLevel, roles, scopeOverrides, expiryDate);
         var created = await _repository.AddAsync(entity);
 
         if (_options.AutoLockKeys)
@@ -110,7 +110,7 @@ public class ApiKeyAdministrationService : IApiKeyAdministrationService
     {
         var item = await _repository.GetAsync(key);
         VerifyTeamOwnership(item, teamKey);
-        var refreshed = BuildKey(teamKey, item.Name, item.Tags, item.AccessLevel ?? AccessLevel.Administrator, item.Roles, item.ExpiryDate);
+        var refreshed = BuildKey(teamKey, item.Name, item.Tags, item.AccessLevel ?? AccessLevel.Administrator, item.Roles, item.ScopeOverrides, item.ExpiryDate);
         await _repository.UpdateAsync(key, refreshed);
 
         if (_options.AutoLockKeys)
@@ -133,6 +133,16 @@ public class ApiKeyAdministrationService : IApiKeyAdministrationService
         var item = await _repository.GetAsync(key);
         VerifyTeamOwnership(item, teamKey);
         await _repository.DeleteAsync(key);
+    }
+
+    /// <inheritdoc />
+    public async Task SetScopeOverridesAsync(string teamKey, string key, string[] scopes)
+    {
+        var item = await _repository.GetAsync(key);
+        VerifyTeamOwnership(item, teamKey);
+        var normalised = scopes is { Length: > 0 } ? scopes : null;
+        var updated = item with { ScopeOverrides = normalised };
+        await _repository.UpdateAsync(key, updated);
     }
 
     /// <inheritdoc />
@@ -219,7 +229,7 @@ public class ApiKeyAdministrationService : IApiKeyAdministrationService
             : null;
     }
 
-    private ApiKeyEntity BuildKey(string teamKey, string name, Dictionary<string, string> tags, AccessLevel accessLevel, string[] roles, DateTime? expiryDate)
+    private ApiKeyEntity BuildKey(string teamKey, string name, Dictionary<string, string> tags, AccessLevel accessLevel, string[] roles, string[] scopeOverrides, DateTime? expiryDate)
     {
         var apiKey = _apiKeyService.BuildApiKey(teamKey, () => StringExtension.GetRandomString(24, 32));
         var encryptedApiKey = _apiKeyService.Encrypt(apiKey);
@@ -235,6 +245,7 @@ public class ApiKeyAdministrationService : IApiKeyAdministrationService
             ApiKeyHash = encryptedApiKey,
             AccessLevel = accessLevel,
             Roles = roles,
+            ScopeOverrides = scopeOverrides,
             ExpiryDate = expiryDate,
             CreatedAt = DateTime.UtcNow,
         };

--- a/Tharga.Team.Service/ApiKeyManagementService.cs
+++ b/Tharga.Team.Service/ApiKeyManagementService.cs
@@ -20,10 +20,11 @@ public class ApiKeyManagementService : IApiKeyManagementService
     }
 
     public IAsyncEnumerable<IApiKey> GetKeysAsync(string teamKey) => _inner.GetKeysAsync(teamKey);
-    public Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, DateTime? expiryDate = null) => _inner.CreateKeyAsync(teamKey, name, accessLevel, roles, expiryDate);
+    public Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null) => _inner.CreateKeyAsync(teamKey, name, accessLevel, roles, scopeOverrides, expiryDate);
     public Task<IApiKey> RefreshKeyAsync(string teamKey, string key) => _inner.RefreshKeyAsync(teamKey, key);
     public Task LockKeyAsync(string teamKey, string key) => _inner.LockKeyAsync(teamKey, key);
     public Task DeleteKeyAsync(string teamKey, string key) => _inner.DeleteKeyAsync(teamKey, key);
+    public Task SetScopeOverridesAsync(string teamKey, string key, string[] scopes) => _inner.SetScopeOverridesAsync(teamKey, key, scopes);
 
     public IAsyncEnumerable<IApiKey> GetSystemKeysAsync() => _inner.GetSystemKeysAsync();
     public Task<IApiKey> CreateSystemKeyAsync(string name, string[] scopes, DateTime? expiryDate = null)

--- a/Tharga.Team.Service/Audit/AuditingApiKeyServiceDecorator.cs
+++ b/Tharga.Team.Service/Audit/AuditingApiKeyServiceDecorator.cs
@@ -30,12 +30,12 @@ public class AuditingApiKeyServiceDecorator : IApiKeyAdministrationService
 
     // Mutation operations — log audit entries
 
-    public async Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, DateTime? expiryDate = null)
+    public async Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null)
     {
         var sw = Stopwatch.StartNew();
         try
         {
-            var result = await _inner.CreateKeyAsync(teamKey, name, accessLevel, roles, expiryDate);
+            var result = await _inner.CreateKeyAsync(teamKey, name, accessLevel, roles, scopeOverrides, expiryDate);
             sw.Stop();
             Log("create", nameof(CreateKeyAsync), sw.ElapsedMilliseconds, true, teamKey: teamKey);
             return result;
@@ -96,6 +96,23 @@ public class AuditingApiKeyServiceDecorator : IApiKeyAdministrationService
         {
             sw.Stop();
             Log("delete", nameof(DeleteKeyAsync), sw.ElapsedMilliseconds, false, ex.Message, teamKey);
+            throw;
+        }
+    }
+
+    public async Task SetScopeOverridesAsync(string teamKey, string key, string[] scopes)
+    {
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            await _inner.SetScopeOverridesAsync(teamKey, key, scopes);
+            sw.Stop();
+            Log("set-scope-overrides", nameof(SetScopeOverridesAsync), sw.ElapsedMilliseconds, true, teamKey: teamKey);
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            Log("set-scope-overrides", nameof(SetScopeOverridesAsync), sw.ElapsedMilliseconds, false, ex.Message, teamKey);
             throw;
         }
     }

--- a/Tharga.Team/IApiKeyAdministrationService.cs
+++ b/Tharga.Team/IApiKeyAdministrationService.cs
@@ -12,7 +12,7 @@ public interface IApiKeyAdministrationService
     IAsyncEnumerable<IApiKey> GetKeysAsync(string teamKey);
 
     /// <summary>Creates a new API key with the specified settings (advanced mode).</summary>
-    Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, DateTime? expiryDate = null);
+    Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null);
 
     /// <summary>Generates a new API key value for an existing key entry. Returns the entity with the raw key visible once.</summary>
     Task<IApiKey> RefreshKeyAsync(string teamKey, string key);
@@ -22,6 +22,12 @@ public interface IApiKeyAdministrationService
 
     /// <summary>Deletes an API key. Verifies team ownership.</summary>
     Task DeleteKeyAsync(string teamKey, string key);
+
+    /// <summary>
+    /// Sets the <c>ScopeOverrides</c> array on an existing team API key. Verifies team ownership.
+    /// Pass <c>null</c> or an empty array to clear all overrides.
+    /// </summary>
+    Task SetScopeOverridesAsync(string teamKey, string key, string[] scopes);
 
     /// <summary>Returns all system-level API keys (not bound to a team).</summary>
     IAsyncEnumerable<IApiKey> GetSystemKeysAsync();

--- a/Tharga.Team/IApiKeyManagementService.cs
+++ b/Tharga.Team/IApiKeyManagementService.cs
@@ -9,7 +9,7 @@ public interface IApiKeyManagementService
     IAsyncEnumerable<IApiKey> GetKeysAsync(string teamKey);
 
     [RequireScope(ApiKeyScopes.Manage)]
-    Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, DateTime? expiryDate = null);
+    Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null);
 
     [RequireScope(ApiKeyScopes.Manage)]
     Task<IApiKey> RefreshKeyAsync(string teamKey, string key);
@@ -19,6 +19,9 @@ public interface IApiKeyManagementService
 
     [RequireScope(ApiKeyScopes.Manage)]
     Task DeleteKeyAsync(string teamKey, string key);
+
+    [RequireScope(ApiKeyScopes.Manage)]
+    Task SetScopeOverridesAsync(string teamKey, string key, string[] scopes);
 
     [RequireScope(ApiKeyScopes.SystemManage)]
     IAsyncEnumerable<IApiKey> GetSystemKeysAsync();

--- a/docs/implementation-guide.md
+++ b/docs/implementation-guide.md
@@ -362,7 +362,7 @@ builder.Services.AddThargaTeamBlazor(o =>
     o.Title = "My App";
     o.AutoCreateFirstTeam = true;          // default: false — auto-creates a team for first-time users
     o.ShowMemberRoles = false;             // default: false — shows tenant role assignment in team UI
-    o.ShowScopeOverrides = false;          // default: false — shows scope override controls in team UI
+    o.ShowScopeOverrides = false;          // default: false — shows scope override controls in TeamComponent (team-member UI). For ApiKeyView, opt in via the [Parameter] ShowScopeOverrides on the component itself; the two flags are intentionally independent.
     o.RegisterTeamService<MyTeamService, MyUserService>();
 });
 
@@ -490,7 +490,7 @@ public class MyTeamService : TeamServiceRepositoryBase<TeamEntity, TeamMember>
 | `<TeamComponent />` | Full team management (create, rename, delete, members) |
 | `<TeamInviteView />` | Pending invitation view |
 | `<UsersView />` | Admin user list |
-| `<ApiKeyView />` | API key management (requires Step 5) |
+| `<ApiKeyView />` | API key management (requires Step 5). Opt-in `[Parameter]` flags: `ShowAuditLogButton`, `ShowScopeOverrides` (Scopes column + create-card multi-select + Edit-Scopes dialog per row) |
 | `<AuditLogView />` | Audit log viewer (requires Step 8) |
 | `Roles.TeamMember` | Role claim added to authenticated team members |
 | `Roles.Developer` | Role for developer-only UI sections |

--- a/plan/feature.md
+++ b/plan/feature.md
@@ -1,0 +1,61 @@
+# Feature: ApiKeyView — surface per-key scope overrides
+
+GitHub issue: [Tharga/Platform#71](https://github.com/Tharga/Platform/issues/71)
+
+## Goal
+
+Operators currently have no UI affordance to recognise or modify per-key `ScopeOverrides` on team API keys. The entity field exists and is honoured by the auth pipeline, but `ApiKeyView` (rendered on `/apikey`) neither shows nor edits it. Downstream this means narrow-scope keys (e.g. Quilt4Net.Server's Value Group keys minted with a single `valuegroup:read` scope) look indistinguishable from any other team key in the admin grid.
+
+This feature adds an opt-in UI surface for viewing and editing `ScopeOverrides` per row, plus the service-layer plumbing required to persist edits.
+
+## Scope
+
+Three layers:
+
+### 1. Service layer (`Tharga.Team.Service`)
+
+- Add `Task SetScopeOverridesAsync(string teamKey, string key, string[] scopes)` to `IApiKeyAdministrationService` and `IApiKeyManagementService`. The management interface declares `[RequireScope(ApiKeyScopes.Manage)]` for parity with the rest of its surface. Implementation reads the entity, verifies team ownership, applies `entity with { ScopeOverrides = scopes }`, and persists via the existing `IApiKeyRepository.UpdateAsync`.
+- Extend `CreateKeyAsync` on both interfaces with an optional `string[] scopeOverrides = null` parameter. Default `null` keeps the existing behaviour (no overrides on new keys); existing callers compile unchanged. `BuildKey` in `ApiKeyAdministrationService` is updated to set the field on the new entity.
+
+### 2. Blazor layer (`Tharga.Team.Blazor.Features.Api.ApiKeyView`)
+
+- New `[Parameter] public bool ShowScopeOverrides { get; set; }`. Default `false`. Mirrors the existing `ShowAuditLogButton` opt-in pattern so consumers can enable scope management on `/developer/apikey` without affecting `/apikey`, or vice versa.
+- When `ShowScopeOverrides && _scopeRegistry != null && _options.AdvancedMode`:
+  - **Display column.** A new "Scopes" column showing the comma-separated `ScopeOverrides` values for each row. The existing effective-scopes info tooltip stays.
+  - **Create card field.** A `RadzenDropDown TValue="IEnumerable<string>"` with `Multiple="true"`, populated from `_scopeRegistry.All`. Selected values flow into the new `CreateKeyAsync` parameter.
+  - **Edit-Scopes dialog per row.** A new icon button (e.g. `tune`) on each row opens a modal hosting a multi-select with the current values pre-checked. Save calls `SetScopeOverridesAsync`; cancel closes without persisting. Reuses Radzen `DialogService.OpenAsync` (the same primitive `OpenAuditLogAsync` already uses).
+- No change to the existing effective-scopes info tooltip — it already shows the override/access-level/role provenance.
+
+### 3. Documentation
+
+- `Tharga.Team.Blazor/README.md` mentions the new parameter under the `ApiKeyView` section if there is one (verify in step 6).
+- `docs/implementation-guide.md` clarifies that `ShowScopeOverrides` (the existing `ThargaBlazorOptions` flag) gates the **team-member** UI, while the new `[Parameter]` on `ApiKeyView` is independent — these are intentionally separate per-component controls.
+
+## Behaviour
+
+- **No data migration.** Existing keys have `ScopeOverrides == null`. The display column renders empty for those rows; nothing else changes.
+- **No new scopes registered.** Mutation is gated by the existing `ApiKeyScopes.Manage` scope on `IApiKeyManagementService`.
+- **No effect when `ShowScopeOverrides = false`.** Existing callers see no UI difference; defaults preserved.
+- **Decorator pass-through.** `AuditingApiKeyServiceDecorator` *does* exist (correction from initial scoping). The new `SetScopeOverridesAsync` gets an audit-logging wrapper with action `"set-scope-overrides"`; the extended `CreateKeyAsync` keeps its existing audit wrapper with the new parameter forwarded through.
+
+## Acceptance criteria
+
+1. `IApiKeyAdministrationService` exposes `Task SetScopeOverridesAsync(string teamKey, string key, string[] scopes)`. `IApiKeyManagementService` mirrors it with `[RequireScope(ApiKeyScopes.Manage)]`.
+2. `IApiKeyAdministrationService.CreateKeyAsync` and `IApiKeyManagementService.CreateKeyAsync` accept an optional `string[] scopeOverrides = null` parameter. Existing call sites compile unchanged.
+3. `ApiKeyView` has `[Parameter] public bool ShowScopeOverrides { get; set; }` defaulting to `false`. With it on, the grid surfaces a Scopes column, the create card has a multi-select, and each row gets an Edit-Scopes icon button.
+4. Edit-Scopes dialog calls `IApiKeyManagementService.SetScopeOverridesAsync` and refreshes the grid on save.
+5. New unit tests cover: `SetScopeOverridesAsync` updates the entity and verifies team ownership; `CreateKeyAsync` with `scopeOverrides` sets the field on the persisted entity; `ApiKeyView.ShowScopeOverrides` parameter exists with `[Parameter]` attribute and bool type (reflection smoke test, matching `TeamComponentMemberNameEditTests` pattern).
+6. `dotnet build -c Release` clean. `dotnet test -c Release` green.
+
+## Done condition
+
+PR opened from `feature/apikey-scope-overrides-ui` → `master`, all CI checks green, user has confirmed.
+
+## Out of scope
+
+- Editing `Roles` from the UI — the grid currently shows roles but has no edit affordance; out of this feature's scope.
+- Inline-edit (vs dialog) for ScopeOverrides — rejected in planning (multi-select grid cells are cramped).
+- `ScopeOverrides` on system keys — they already use `SystemScopes` (different field, set at creation only via `CreateSystemKeyAsync`). No UI change there.
+- Validation that selected scopes are registered with the `IScopeRegistry` — the picker is populated from the registry, so out-of-band values aren't expected. Server-side validation can be added later if a non-UI caller (CLI, API) needs guardrails.
+- Audit logging of `SetScopeOverridesAsync` invocations — no existing `AuditingApiKeyServiceDecorator` exists; we don't introduce one in this feature. The audit log already records the call via `ScopeProxy`.
+- Framework package bumps (Microsoft.AspNetCore.* 9.0.x → 10.0.x on net9.0) — deferred, separate PR.

--- a/plan/plan.md
+++ b/plan/plan.md
@@ -1,0 +1,58 @@
+# Plan: ApiKeyView — surface per-key scope overrides
+
+## Steps
+
+- [x] **1. Service layer — `IApiKeyAdministrationService`**
+  - Add `Task SetScopeOverridesAsync(string teamKey, string key, string[] scopes);` to the interface.
+  - Extend the signature of `CreateKeyAsync` with `string[] scopeOverrides = null` (positioned before `expiryDate`).
+  - Implementation in `ApiKeyAdministrationService`:
+    - `SetScopeOverridesAsync` — load via `_repository.GetAsync(key)`, call `VerifyTeamOwnership(item, teamKey)`, build `item with { ScopeOverrides = scopes }`, persist via `_repository.UpdateAsync(key, updated)`.
+    - Update `CreateKeyAsync` to forward `scopeOverrides` into `BuildKey`. Pass `null` (not `Array.Empty<string>`) when the caller didn't set anything — keeps the `BsonIgnoreIfNull` attribute on the entity in play.
+    - Update private `BuildKey` to accept and assign `ScopeOverrides`.
+
+- [x] **2. Service layer — `IApiKeyManagementService` (user-facing wrapper)**
+  - Add `Task SetScopeOverridesAsync(string teamKey, string key, string[] scopes);` to the interface with `[RequireScope(ApiKeyScopes.Manage)]`.
+  - Extend `CreateKeyAsync` signature with `string[] scopeOverrides = null`.
+  - Update `ApiKeyManagementService` (the concrete delegation class) to forward both: `_inner.SetScopeOverridesAsync(...)` and the extended `_inner.CreateKeyAsync(...)`.
+
+- [x] **3. Blazor layer — `ApiKeyView.razor`**
+  - Add `[Parameter] public bool ShowScopeOverrides { get; set; }` next to the existing `ShowAuditLogButton` parameter.
+  - In the grid template, after the existing roles/expiry/info columns and gated by `_options.AdvancedMode && _scopeRegistry != null && ShowScopeOverrides`:
+    - Add a new `RadzenDataGridColumn Title="Scopes"` showing `string.Join(", ", context.ScopeOverrides ?? Array.Empty<string>())`.
+    - Add a new action button `<RadzenButton Icon="tune" Click="@(_ => OpenEditScopesAsync(context))" />` inside the existing actions column. Update `GetActionsColumnWidth()` to account for the extra 40px when `ShowScopeOverrides` is on.
+  - In the create card, gated by the same condition, add a `RadzenDropDown TValue="IEnumerable<string>" Multiple="true"` bound to `_newScopeOverrides`, populated from `_scopeRegistry.All.Select(s => s.Name)`. Pass it through to `_apiKeyManagementService.CreateKeyAsync(...)` and reset on success.
+  - New `OpenEditScopesAsync(ApiKeyModel context)` method that opens a dialog. Dialog content is a small component or inline `RenderFragment` with a multi-select pre-populated from `context.ScopeOverrides` plus Save/Cancel buttons. On Save: call `_apiKeyManagementService.SetScopeOverridesAsync(_selectedTeam.Key, context.Key, selected.ToArray())` then `await ReloadData()`.
+
+- [x] **4. Tests**
+  - `Tharga.Team.Service.Tests/ApiKeyAdministrationServiceTests.cs` — append:
+    - `SetScopeOverridesAsync_Updates_Entity` — substitute `IApiKeyRepository.GetAsync` to return a known entity for team `T-1`; assert `UpdateAsync` received an entity with the new `ScopeOverrides`.
+    - `SetScopeOverridesAsync_WrongTeam_Throws` — entity belongs to T-1; calling with T-2 throws `UnauthorizedAccessException`.
+    - `CreateKeyAsync_With_ScopeOverrides_Sets_Field` — assert the entity passed to `_repository.AddAsync` has the expected `ScopeOverrides` array.
+  - `Tharga.Team.Blazor.Tests/ApiKeyViewScopeOverridesTests.cs` (new file) — reflection smoke test in the existing `TeamComponentMemberNameEditTests` style: assert `ApiKeyView.ShowScopeOverrides` exists, is `bool`, has `[Parameter]` attribute, and defaults to `false`.
+
+- [x] **5. Build + full test suite**
+  - `dotnet build -c Release` clean.
+  - `dotnet test -c Release` green.
+
+- [x] **6. README and docs**
+  - `Tharga.Team.Blazor/README.md`: brief mention of the new `ShowScopeOverrides` parameter on `ApiKeyView` if the README documents component parameters (verify).
+  - `docs/implementation-guide.md`: clarify that the existing `ThargaBlazorOptions.ShowScopeOverrides` flag gates the **team-member** UI (TeamComponent), while the new `ApiKeyView.ShowScopeOverrides` `[Parameter]` is independent and per-component.
+
+- [x] **7. Commit + push the feature branch**
+  - Conventional prefix: `feat:` — this adds new public surface.
+  - Suggested message: `feat: ApiKeyView scope-overrides UI + SetScopeOverridesAsync service API`.
+
+- [x] **8. Pause for user verification.** Plan/ stays on the feature branch; deleted in the close-out commit before the PR opens.
+
+## Verification approach
+
+- After step 1+2, build `Tharga.Team.Service` and confirm no callers broke. The new `scopeOverrides` parameter is optional so existing call sites should compile unchanged.
+- After step 3, build `Tharga.Team.Blazor`. Open the sample app locally (`Tharga.Platform.Sample`) and smoke-test on `/apikey` and `/developer/apikey` if either is set up with `ShowScopeOverrides`.
+- After step 4, run the focused service+blazor test projects to confirm new assertions pass before running the full suite in step 5.
+
+## Open questions
+
+(none — three design choices locked via `AskUserQuestion` during planning: per-component `[Parameter]`, dialog + create-card multi-select, both `Create+scopeOverrides` and `SetScopeOverridesAsync`)
+
+## Last session
+2026-05-27 — All implementation steps complete. 7 new tests (5 service-layer + 2 Blazor smoke); 325 total green. READMEs and implementation guide updated. The `AuditingApiKeyServiceDecorator` did exist (correction from initial scoping) — its `CreateKeyAsync` was updated and a new `SetScopeOverridesAsync` audit-logging wrapper added. Ready for commit + push + user verification.


### PR DESCRIPTION
## Summary

Resolves [#71](https://github.com/Tharga/Platform/issues/71). Surfaces per-key \`ScopeOverrides\` on team API keys so operators can recognise and modify narrow-scope keys (e.g. Quilt4Net.Server Value Group keys minted with \`valuegroup:read\`) directly from the standard \`/apikey\` admin page.

## Service layer

- **\`SetScopeOverridesAsync(teamKey, key, scopes)\`** on both \`IApiKeyAdministrationService\` and \`IApiKeyManagementService\`. Loads the entity, verifies team ownership, applies \`entity with { ScopeOverrides = ... }\`, persists via existing \`IApiKeyRepository.UpdateAsync\`. Empty arrays normalise to \`null\` so \`[BsonIgnoreIfNull]\` stays effective.
- **\`CreateKeyAsync\`** on both interfaces gains an optional \`string[] scopeOverrides = null\` parameter (positioned between \`roles\` and \`expiryDate\`). Existing callers were migrated to named arguments.
- **\`AuditingApiKeyServiceDecorator\`** wires audit log entries for both: a new \`set-scope-overrides\` action and the existing \`create\` entry with the new parameter forwarded through.

## Blazor layer

New \`[Parameter] public bool ShowScopeOverrides\` on \`ApiKeyView\` (default \`false\`). When on (and \`IScopeRegistry\` is registered):

- **Scopes column** showing the comma-separated current overrides.
- **Multi-select on the create card** populated from \`IScopeRegistry.All\`, flows through to \`CreateKeyAsync\`.
- **Per-row Edit-Scopes icon button** (\`tune\`) opens a Radzen dialog with a multi-select pre-populated from the current values; Save calls \`SetScopeOverridesAsync\` and reloads the grid.

The new parameter is independent of the existing \`ThargaBlazorOptions.ShowScopeOverrides\` flag — that one continues to gate \`TeamComponent\` only.

## Behaviour change for consumers

- Existing positional callers of \`CreateKeyAsync(team, name, level, null, expiry)\` no longer compile because of the new parameter between \`roles\` and \`expiryDate\`. Migrate to named arguments: \`CreateKeyAsync(team, name, level, roles: null, expiryDate: expiry)\`. Two call sites in this repo were updated as part of the PR.
- \`UpdateAsync\`-based mutation is the persistence path; consumers with a custom \`IApiKeyRepository\` will inherit \`SetScopeOverridesAsync\` working as long as \`UpdateAsync\` is implemented.

## Test plan

- [x] \`dotnet build -c Release\` — 0 warnings, 0 errors
- [x] \`dotnet test -c Release\` — 325 / 325 passing (7 new)
- [x] \`SetScopeOverridesAsync_Updates_Entity\`, \`_EmptyArray_ClearsOverridesToNull\`, \`_WrongTeam_Throws\` (3 tests)
- [x] \`CreateKeyAsync_With_ScopeOverrides_Sets_Field_On_Entity\`, \`_Without_ScopeOverrides_LeavesFieldNull\` (2 tests)
- [x] \`ApiKeyView_HasShowScopeOverridesParameter_DefaultFalse\` + \`ApiKeyView_StillHasShowAuditLogButtonParameter\` regression guard (2 smoke tests via reflection)

## Documentation

- \`Tharga.Team.Blazor/README.md\` mentions both opt-in parameters on \`ApiKeyView\` (\`ShowAuditLogButton\`, \`ShowScopeOverrides\`).
- \`docs/implementation-guide.md\` clarifies that \`ThargaBlazorOptions.ShowScopeOverrides\` gates \`TeamComponent\` only; the \`ApiKeyView\` flag is per-component and independent.