### PR TITLE
feat: add AccessLevel.Custom (no inherited base scopes)

### DIFF
--- a/Tharga.Team.Blazor/Features/Team/InviteUserDialog.razor
+++ b/Tharga.Team.Blazor/Features/Team/InviteUserDialog.razor
@@ -76,7 +76,9 @@
         {
             AccessLevel = AccessLevel.User
         };
-        _accessLevels = Enum.GetValues<AccessLevel>().Where(x => x != AccessLevel.Owner).ToArray();
+        // Custom is hidden from the member picker until #76 adds member scope/role editing
+        // (a Custom member with no editable grants would be locked out). Keys surface it in ApiKeyView.
+        _accessLevels = Enum.GetValues<AccessLevel>().Where(x => x != AccessLevel.Owner && x != AccessLevel.Custom).ToArray();
         _emailSenderAvailable = ServiceProvider.GetService<ITeamEmailSender>() != null;
 
         await base.OnInitializedAsync();

--- a/Tharga.Team.Blazor/Features/Team/TeamComponent.razor
+++ b/Tharga.Team.Blazor/Features/Team/TeamComponent.razor
@@ -124,7 +124,8 @@ else
                                             }
                                             else if (_canChangeRole)
                                             {
-                                                var accessLevels = Enum.GetValues<AccessLevel>().Where(x => x != AccessLevel.Owner);
+                                                // Custom hidden until #76 adds member scope/role editing (see InviteUserDialog).
+                                                var accessLevels = Enum.GetValues<AccessLevel>().Where(x => x != AccessLevel.Owner && x != AccessLevel.Custom);
                                                 <RadzenDropDown TValue="AccessLevel" Value="@context.AccessLevel" ValueChanged="@(x => ChangeRole(team, context.Key, x))" Data="@accessLevels"/>
                                             }
                                             else

--- a/Tharga.Team.Service.Tests/AccessLevelProxyTests.cs
+++ b/Tharga.Team.Service.Tests/AccessLevelProxyTests.cs
@@ -130,4 +130,19 @@ public class AccessLevelProxyTests
         var proxy = CreateProxy("team-1", "Administrator");
         Assert.Throws<InvalidOperationException>(() => proxy.UnprotectedMethod());
     }
+
+    [Fact]
+    public void Custom_Cannot_Call_Viewer_Method()
+    {
+        // Custom is the lowest tier, so it fails even the least-restrictive access-level gate.
+        var proxy = CreateProxy("team-1", "Custom");
+        Assert.Throws<UnauthorizedAccessException>(() => proxy.ViewerMethod());
+    }
+
+    [Fact]
+    public void Custom_Cannot_Call_Admin_Method()
+    {
+        var proxy = CreateProxy("team-1", "Custom");
+        Assert.Throws<UnauthorizedAccessException>(() => proxy.AdminMethod());
+    }
 }

--- a/Tharga.Team.Service.Tests/AccessLevelTests.cs
+++ b/Tharga.Team.Service.Tests/AccessLevelTests.cs
@@ -1,0 +1,18 @@
+using Tharga.Team;
+
+namespace Tharga.Team.Service.Tests;
+
+public class AccessLevelTests
+{
+    [Fact]
+    public void Custom_Is_The_Lowest_Privilege_Tier()
+    {
+        // The whole Custom design relies on it being the highest numeric value (lowest privilege):
+        // it must fail every `accessLevel > minimumLevel` gate and resolve to no base scopes.
+        var max = Enum.GetValues<AccessLevel>().Max();
+
+        Assert.Equal(AccessLevel.Custom, max);
+        Assert.True(AccessLevel.Custom > AccessLevel.Viewer);
+        Assert.True(AccessLevel.Custom > AccessLevel.Administrator);
+    }
+}

--- a/Tharga.Team.Service.Tests/ApiKeyAdministrationServiceTests.cs
+++ b/Tharga.Team.Service.Tests/ApiKeyAdministrationServiceTests.cs
@@ -273,6 +273,26 @@ public class ApiKeyAdministrationServiceTests
         await _repository.Received(1).AddAsync(Arg.Is<ApiKeyEntity>(e => e.ScopeOverrides == null));
     }
 
+    [Fact]
+    public async Task CreateKeyAsync_With_Custom_AccessLevel_Persists_Custom_And_Overrides()
+    {
+        // The headline #74 use case: a least-privilege machine key minted with Custom + a single
+        // explicit override, carrying no inherited base scopes.
+        _apiKeyService.BuildApiKey(Arg.Any<string>(), Arg.Any<Func<string>>()).Returns("new-key");
+        _apiKeyService.Encrypt("new-key").Returns("new-hash");
+        _repository.AddAsync(Arg.Any<ApiKeyEntity>()).Returns(ci => Task.FromResult(ci.Arg<ApiKeyEntity>()));
+
+        var created = await _sut.CreateKeyAsync("team-1", "Value Group reader", AccessLevel.Custom,
+            roles: null, scopeOverrides: new[] { "valuegroup:read" });
+
+        Assert.Equal(AccessLevel.Custom, created.AccessLevel);
+        await _repository.Received(1).AddAsync(Arg.Is<ApiKeyEntity>(e =>
+            e.AccessLevel == AccessLevel.Custom
+            && e.ScopeOverrides != null
+            && e.ScopeOverrides.Length == 1
+            && e.ScopeOverrides[0] == "valuegroup:read"));
+    }
+
     private static ApiKeyEntity CreateEntity(string key, string hash, string teamKey)
     {
         return new ApiKeyEntity

--- a/Tharga.Team.Service.Tests/ScopeRegistryTests.cs
+++ b/Tharga.Team.Service.Tests/ScopeRegistryTests.cs
@@ -68,4 +68,50 @@ public class ScopeRegistryTests
 
         Assert.Throws<InvalidOperationException>(() => registry.Register("doc:read", AccessLevel.User));
     }
+
+    [Fact]
+    public void Custom_Gets_No_Base_Scopes()
+    {
+        var registry = new ScopeRegistry();
+        registry.Register("doc:read", AccessLevel.Viewer);
+        registry.Register("doc:download", AccessLevel.User);
+        registry.Register("doc:delete", AccessLevel.Administrator);
+
+        var scopes = registry.GetScopesForAccessLevel(AccessLevel.Custom);
+
+        Assert.Empty(scopes);
+    }
+
+    [Fact]
+    public void Custom_Ignores_Scope_Registered_At_Custom()
+    {
+        // Defensive: even if a scope is registered at Custom level, Custom resolves to no base scopes.
+        var registry = new ScopeRegistry();
+        registry.Register("doc:read", AccessLevel.Viewer);
+        registry.Register("doc:custom", AccessLevel.Custom);
+
+        var scopes = registry.GetScopesForAccessLevel(AccessLevel.Custom);
+
+        Assert.Empty(scopes);
+    }
+
+    [Fact]
+    public void Custom_Effective_Scopes_Are_Roles_Union_Overrides_Only()
+    {
+        var registry = new ScopeRegistry();
+        registry.Register("doc:read", AccessLevel.Viewer);
+        registry.Register("doc:delete", AccessLevel.Administrator);
+
+        var roleRegistry = Substitute.For<ITenantRoleRegistry>();
+        roleRegistry.GetScopesForRoles(Arg.Any<IEnumerable<string>>()).Returns(new[] { "role:scope" });
+        registry.SetRoleRegistry(roleRegistry);
+
+        var scopes = registry.GetEffectiveScopes(AccessLevel.Custom, new[] { "editor" }, new[] { "override:scope" });
+
+        Assert.Equal(2, scopes.Count);
+        Assert.Contains("role:scope", scopes);
+        Assert.Contains("override:scope", scopes);
+        Assert.DoesNotContain("doc:read", scopes);
+        Assert.DoesNotContain("doc:delete", scopes);
+    }
 }

--- a/Tharga.Team/AccessLevel.cs
+++ b/Tharga.Team/AccessLevel.cs
@@ -5,5 +5,13 @@ public enum AccessLevel
     Owner,
     Administrator,
     User,
-    Viewer
+    Viewer,
+
+    /// <summary>
+    /// Grants no inherited base scopes. A principal at this level has exactly the scopes from
+    /// its assigned roles and <c>ScopeOverrides</c> — nothing from the access-level tier itself,
+    /// and it is exempt from the "Owner/Administrator get all registered scopes" rule. Use for
+    /// least-privilege machine keys that should carry only their explicit grants.
+    /// </summary>
+    Custom
 }

--- a/Tharga.Team/README.md
+++ b/Tharga.Team/README.md
@@ -20,7 +20,7 @@ Domain models, service abstractions, and authorization primitives for multi-tena
 - `IApiKeyAdministrationService` / `IApiKeyManagementService` - API key management.
 
 ### Authorization
-- `AccessLevel` enum - Owner, Administrator, User, Viewer.
+- `AccessLevel` enum - Owner, Administrator, User, Viewer, Custom. `Custom` grants no inherited base scopes (effective scopes = roles ∪ scope overrides only) for least-privilege keys/members.
 - `TeamClaimTypes` - Claim type constants (`TeamKey`, `AccessLevel`, `Scope`).
 - `IScopeRegistry` / `ScopeRegistry` - Register and resolve scopes per access level.
 - `ITenantRoleRegistry` / `TenantRoleRegistry` - Register tenant roles with associated scopes.

--- a/Tharga.Team/ScopeRegistry.cs
+++ b/Tharga.Team/ScopeRegistry.cs
@@ -5,6 +5,8 @@ namespace Tharga.Team;
 /// Owner and Administrator get all registered scopes.
 /// User gets scopes registered at User or Viewer level.
 /// Viewer gets only scopes registered at Viewer level.
+/// Custom gets no base scopes at all (exempt from the Owner/Administrator all-scopes rule);
+/// its effective scopes come solely from roles and scope overrides.
 /// Role scopes are unioned with access level scopes.
 /// </summary>
 public class ScopeRegistry : IScopeRegistry
@@ -29,6 +31,11 @@ public class ScopeRegistry : IScopeRegistry
 
     public IReadOnlyList<string> GetScopesForAccessLevel(AccessLevel accessLevel)
     {
+        // Custom grants no base scopes — effective scopes come solely from roles and overrides.
+        // Explicit guard so the invariant holds even if a scope is ever registered at Custom level.
+        if (accessLevel == AccessLevel.Custom)
+            return Array.Empty<string>();
+
         if (accessLevel <= AccessLevel.Administrator)
             return _scopes.Select(s => s.Name).ToList();
 

--- a/docs/implementation-guide.md
+++ b/docs/implementation-guide.md
@@ -688,9 +688,11 @@ The `ScopeProxy<T>` automatically checks that the current user has the required 
 
 ### How scopes are resolved
 
-1. **Access level** — Owner and Administrator get all scopes. User gets scopes at User or Viewer level. Viewer gets only Viewer-level scopes.
+1. **Access level** — Owner and Administrator get all scopes. User gets scopes at User or Viewer level. Viewer gets only Viewer-level scopes. **`Custom` gets no base scopes** (and is exempt from the Owner/Administrator "all scopes" rule).
 2. **Tenant roles** — Additional scopes granted by assigned roles (see Step 7).
 3. **Scope overrides** — Per-member overrides set in the team management UI (when `ShowScopeOverrides = true`).
+
+> **`AccessLevel.Custom` — least-privilege keys/members.** Use `Custom` when a principal should carry *only* its explicitly assigned roles and scope overrides, with nothing inherited from the access-level tier — e.g. a machine API key minted with a single scope. Its effective scopes are exactly `roles ∪ scopeOverrides`. Set it **explicitly**: a key created without an access level still defaults to a non-`Custom` level. `Custom` is surfaced in the `ApiKeyView` create card; it is intentionally hidden from the team-member pickers until member scope/role editing lands ([#76](https://github.com/Tharga/Platform/issues/76)).
 
 ### Built-in scopes
 
@@ -715,6 +717,8 @@ builder.Services.AddScopedWithAccessLevel<IMyService, MyService>();
 [RequireAccessLevel(AccessLevel.Administrator)]
 public Task DeleteAsync(string id) { ... }
 ```
+
+> A `Custom` principal is the lowest tier and fails **every** `[RequireAccessLevel]` gate (including `Viewer`). Authorize such principals with scope-based checks (`[RequireScope]`) rather than access-level enforcement.
 
 ### Verification
 


### PR DESCRIPTION
## `AccessLevel.Custom` — least-privilege keys & members

Adds a new `AccessLevel.Custom` tier that grants **no inherited base scopes**. A principal at this level carries exactly its assigned roles + `ScopeOverrides` and nothing else — and it is **exempt from the "Owner/Administrator get all registered scopes" rule**.

Closes #74.

### Why
Previously the lowest tier was `Viewer` (which carries read scopes), and there was no way to mint a *minimal* key — a key minted at `Viewer` with one scope override still inherited the whole `Viewer` read set. This makes true least-privilege machine keys impossible and clutters the API-key scope list.

### What's new
- **`AccessLevel.Custom`** — effective scopes = `roles ∪ ScopeOverrides` only.
- Resolves to an empty base scope set in `ScopeRegistry` (explicit guard, so the invariant holds even if a scope is registered at that level).
- It is the lowest-privilege tier, so it fails **every** `[RequireAccessLevel]` gate — authorize `Custom` principals with scope-based checks (`[RequireScope]`) instead.

### How to use
Mint a least-privilege API key programmatically — no new API, the existing `CreateKeyAsync` already takes the level:

```csharp
await apiKeyService.CreateKeyAsync(
    teamKey,
    "Value Group reader",
    AccessLevel.Custom,
    scopeOverrides: new[] { "valuegroup:read" });
// → key carries only "valuegroup:read", nothing inherited
```

Set `Custom` **explicitly** — a key created without an access level still defaults to a non-`Custom` level.

### UI
- `Custom` appears in the **`ApiKeyView`** create-card access-level dropdown.
- It is intentionally **hidden from the team-member pickers** (`TeamComponent`, `InviteUserDialog`) for now: without member scope/role editing a `Custom` member would have no way to receive grants. Surfacing `Custom` for members is tracked in #76.

### Compatibility
Backwards compatible — existing levels and scope resolution are unchanged; `Custom` is a new, additional lowest tier.

### Tests & docs
7 new tests (scope resolution, `AccessLevelProxy` rejection, enum-ordering invariant, create-through with `Custom`). Implementation guide + `Tharga.Team` README updated.
