### PR TITLE
feat: system-set API key tags (surfaced as claims)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  MAJOR_MINOR: '2.1'
+  MAJOR_MINOR: '2.2'
 
 permissions:
   contents: write

--- a/Tharga.Platform.Sample/Components/Pages/ApiKeysPage.razor
+++ b/Tharga.Platform.Sample/Components/Pages/ApiKeysPage.razor
@@ -5,4 +5,7 @@
 
 <PageTitle>API Keys</PageTitle>
 
-<ApiKeyView ShowAuditLogButton="true" />
+<SpecialApiKeyCreator />
+
+<RadzenText TextStyle="TextStyle.H6" class="rz-mb-2">Team API keys</RadzenText>
+<ApiKeyView ShowAuditLogButton="true" ShowScopeOverrides="true" ChipTagKeys="@(new[] { "Type" })" />

--- a/Tharga.Platform.Sample/Components/SpecialApiKeyCreator.razor
+++ b/Tharga.Platform.Sample/Components/SpecialApiKeyCreator.razor
@@ -1,0 +1,122 @@
+@using Microsoft.Extensions.DependencyInjection
+@using Tharga.Team
+@using Tharga.Team.Blazor.Features.Team
+@inject ITeamStateService TeamStateService
+@inject IServiceProvider ServiceProvider
+@inject NotificationService NotificationService
+
+@*
+    Demonstrates creating a "special" least-privilege API key:
+    AccessLevel.Custom (no inherited base scopes) + explicit scope overrides + system-set Tags.
+    Tags are backend-only (no input in the stock ApiKeyView create card), so this custom form shows
+    how a consumer mints such keys via IApiKeyManagementService.CreateKeyAsync(.., tags: ..).
+*@
+<RadzenCard class="rz-mb-4">
+    <RadzenText TextStyle="TextStyle.H6">Create special API key</RadzenText>
+    <RadzenText TextStyle="TextStyle.Body2" class="rz-mb-3">
+        Creates a least-privilege key (<code>AccessLevel.Custom</code>) carrying only the scopes you pick,
+        plus system-set tags. Reload after creating to see it in the list below.
+    </RadzenText>
+
+    @if (_apiKeyManagementService == null)
+    {
+        <RadzenAlert AlertStyle="AlertStyle.Warning" ShowIcon="true" Variant="Variant.Flat">
+            API key management is not configured.
+        </RadzenAlert>
+    }
+    else if (_scopeRegistry == null)
+    {
+        <RadzenAlert AlertStyle="AlertStyle.Warning" ShowIcon="true" Variant="Variant.Flat">
+            No scope registry configured. Register scopes via <code>o.ConfigureScopes</code> in Program.cs.
+        </RadzenAlert>
+    }
+    else
+    {
+        <div class="rz-mb-2">
+            <RadzenText TextStyle="TextStyle.Subtitle2">Name</RadzenText>
+            <RadzenTextBox @bind-Value="_name" Placeholder="e.g. Firewall opener" Style="width:100%" />
+        </div>
+        <div class="rz-mb-2">
+            <RadzenText TextStyle="TextStyle.Subtitle2">Type tag(s) — shown as chips in the list</RadzenText>
+            <RadzenDropDown @bind-Value="_types" Data="@_typeOptions" Multiple="true" AllowClear="true"
+                            Placeholder="firewall, PIM, Content…" Style="width:100%" />
+        </div>
+        <div class="rz-mb-2">
+            <RadzenText TextStyle="TextStyle.Subtitle2">Scopes (scope overrides)</RadzenText>
+            <RadzenDropDown @bind-Value="_scopes" Data="@_scopeOptions" Multiple="true" AllowClear="true"
+                            Placeholder="Pick scopes…" Style="width:100%" />
+        </div>
+        <div class="rz-display-flex rz-mb-2" style="gap:.5rem">
+            <div style="flex:1">
+                <RadzenText TextStyle="TextStyle.Subtitle2">Extra tag key (optional)</RadzenText>
+                <RadzenTextBox @bind-Value="_extraKey" Placeholder="e.g. firewall.groupId" Style="width:100%" />
+            </div>
+            <div style="flex:1">
+                <RadzenText TextStyle="TextStyle.Subtitle2">Extra tag value</RadzenText>
+                <RadzenTextBox @bind-Value="_extraValue" Placeholder="e.g. ABC123" Style="width:100%" />
+            </div>
+        </div>
+        <RadzenButton Text="Create special key" Icon="vpn_key" Click="@CreateAsync"
+                      Disabled="@(string.IsNullOrWhiteSpace(_name))" class="rz-mt-2" />
+
+        @if (_createdKey != null)
+        {
+            <RadzenAlert AlertStyle="AlertStyle.Success" ShowIcon="true" Variant="Variant.Flat" class="rz-mt-3">
+                Created <b>@_createdKey.Name</b> — copy the value now (shown once):
+                <pre style="white-space:pre-wrap; margin:.5rem 0 0">@_createdKey.ApiKey</pre>
+            </RadzenAlert>
+        }
+    }
+</RadzenCard>
+
+@code {
+    private IApiKeyManagementService _apiKeyManagementService;
+    private IScopeRegistry _scopeRegistry;
+
+    private string _name;
+    private IEnumerable<string> _types = Array.Empty<string>();
+    private IEnumerable<string> _scopes = Array.Empty<string>();
+    private string _extraKey;
+    private string _extraValue;
+    private IApiKey _createdKey;
+
+    private readonly string[] _typeOptions = ["firewall", "PIM", "Content"];
+    private string[] _scopeOptions = [];
+
+    protected override void OnInitialized()
+    {
+        _apiKeyManagementService = ServiceProvider.GetService<IApiKeyManagementService>();
+        _scopeRegistry = ServiceProvider.GetService<IScopeRegistry>();
+        if (_scopeRegistry != null)
+            _scopeOptions = _scopeRegistry.All.Select(s => s.Name).ToArray();
+    }
+
+    private async Task CreateAsync()
+    {
+        var team = await TeamStateService.GetSelectedTeamAsync();
+        if (team?.Key == null)
+        {
+            NotificationService.Notify(NotificationSeverity.Warning, "No team selected.");
+            return;
+        }
+
+        var tags = new List<Tag>();
+        foreach (var type in _types ?? Enumerable.Empty<string>())
+            tags.Add(new Tag("Type", type));
+        if (!string.IsNullOrWhiteSpace(_extraKey) && !string.IsNullOrWhiteSpace(_extraValue))
+            tags.Add(new Tag(_extraKey.Trim(), _extraValue.Trim()));
+
+        var scopes = (_scopes ?? Enumerable.Empty<string>()).ToArray();
+
+        _createdKey = await _apiKeyManagementService.CreateKeyAsync(
+            team.Key, _name, AccessLevel.Custom,
+            roles: null, scopeOverrides: scopes, expiryDate: null, tags: tags);
+
+        NotificationService.Notify(NotificationSeverity.Success, "Special API key created.");
+        _name = null;
+        _types = Array.Empty<string>();
+        _scopes = Array.Empty<string>();
+        _extraKey = null;
+        _extraValue = null;
+    }
+}

--- a/Tharga.Platform.Sample/Program.cs
+++ b/Tharga.Platform.Sample/Program.cs
@@ -27,11 +27,19 @@ builder.AddThargaPlatform(o =>
     //o.Blazor.ShowScopeOverrides = true;
     //o.Blazor.ShowMemberRoles = true;
 
-    //o.ConfigureScopes = scopes =>
-    //{
-    //    scopes.Register("orders:read", AccessLevel.Viewer);
-    //    scopes.Register("orders:write", AccessLevel.Administrator);
-    //};
+    // Advanced mode unlocks the full API key UI (access level, roles, scope overrides, tags).
+    o.ApiKey.AdvancedMode = true;
+
+    // Register scopes so the scope-override picker and Custom (no-base-scope) keys have something to grant.
+    o.ConfigureScopes = scopes =>
+    {
+        scopes.Register("orders:read", AccessLevel.Viewer);
+        scopes.Register("orders:write", AccessLevel.Administrator);
+        scopes.Register("valuegroup:read", AccessLevel.Viewer);
+        scopes.Register("firewall:open", AccessLevel.Administrator);
+        scopes.Register("content:load", AccessLevel.Viewer);
+        scopes.Register("pim:manage", AccessLevel.Administrator);
+    };
 
     //o.ConfigureTenantRoles = roles =>
     //{

--- a/Tharga.Team.Blazor.Tests/ApiKeyViewTagsTests.cs
+++ b/Tharga.Team.Blazor.Tests/ApiKeyViewTagsTests.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Components;
+
+namespace Tharga.Team.Blazor.Tests;
+
+/// <summary>
+/// Smoke tests for the <c>ApiKeyView.ChipTagKeys</c> parameter added under
+/// <see href="https://github.com/Tharga/Platform/issues/75">Tharga/Platform#75</see>.
+/// </summary>
+public class ApiKeyViewTagsTests
+{
+    [Fact]
+    public void ApiKeyView_HasChipTagKeysParameter_DefaultsEmpty()
+    {
+        var componentType = ResolveApiKeyView();
+        var prop = componentType.GetProperty("ChipTagKeys");
+
+        Assert.NotNull(prop);
+        Assert.Equal(typeof(string[]), prop.PropertyType);
+        Assert.NotNull(prop.GetCustomAttribute<ParameterAttribute>());
+
+        var instance = Activator.CreateInstance(componentType);
+        var value = (string[])prop.GetValue(instance);
+        Assert.NotNull(value);
+        Assert.Empty(value);
+    }
+
+    private static Type ResolveApiKeyView()
+    {
+        var blazorAssembly = typeof(Tharga.Team.Blazor.Framework.ThargaBlazorRegistration).Assembly;
+        return blazorAssembly
+            .GetTypes()
+            .Single(t => t.Namespace == "Tharga.Team.Blazor.Features.Api" && t.Name == "ApiKeyView");
+    }
+}

--- a/Tharga.Team.Blazor/Features/Api/ApiKeyModel.cs
+++ b/Tharga.Team.Blazor/Features/Api/ApiKeyModel.cs
@@ -14,5 +14,6 @@ public record ApiKeyModel
     public DateTime? ExpiryDate { get; init; }
     public DateTime? CreatedAt { get; init; }
     public DateTime? LastUsedAt { get; init; }
+    public IReadOnlyList<Tag> Tags { get; init; } = Array.Empty<Tag>();
     public bool IsExpired => ExpiryDate.HasValue && ExpiryDate < DateTime.UtcNow;
 }

--- a/Tharga.Team.Blazor/Features/Api/ApiKeyView.razor
+++ b/Tharga.Team.Blazor/Features/Api/ApiKeyView.razor
@@ -112,6 +112,20 @@ else
                     }
                 </Template>
             </RadzenDataGridColumn>
+            <RadzenDataGridColumn Title="Tags" Width="180px">
+                <Template>
+                    @foreach (var tag in context.Tags.Where(t => ChipTagKeys.Contains(t.Key)))
+                    {
+                        <RadzenBadge Text="@tag.Value" class="rz-mr-1 rz-mb-1" />
+                    }
+                    @if (context.Tags.Count > 0)
+                    {
+                        <span title="@GetKeyTagsText(context)">
+                            <RadzenIcon Icon="info" Style="cursor: help;" />
+                        </span>
+                    }
+                </Template>
+            </RadzenDataGridColumn>
             <RadzenDataGridColumn Width="@GetActionsColumnWidth()">
                 <Template>
                     <RadzenButton Icon="visibility" Click="@(_ => context.VisibleKey = context.ApiKey)" Visible="@(!string.IsNullOrEmpty(context.ApiKey) && context.VisibleKey == _apiKeyMask)" />
@@ -185,6 +199,14 @@ else
     /// </summary>
     [Parameter] public bool ShowScopeOverrides { get; set; }
 
+    /// <summary>
+    /// Tag keys to render as chips in the key row. Tags whose <see cref="Tag.Key"/> is listed here
+    /// show as a badge per value (e.g. a "Type" key on a combination key renders one chip per type).
+    /// All tags — including binding tags not listed here — remain visible in the row's (i) tooltip.
+    /// Default: none (tooltip only).
+    /// </summary>
+    [Parameter] public string[] ChipTagKeys { get; set; } = Array.Empty<string>();
+
     private bool _apiKeyServiceMissing;
     private IApiKeyManagementService _apiKeyManagementService;
     private bool _hasAccess;
@@ -248,6 +270,7 @@ else
                     ExpiryDate = x.ExpiryDate,
                     CreatedAt = x.CreatedAt,
                     LastUsedAt = x.LastUsedAt,
+                    Tags = x.Tags ?? Array.Empty<Tag>(),
                 };
             }).ToArray();
 
@@ -315,6 +338,9 @@ else
         }
         return string.Join("\n", lines);
     }
+
+    private static string GetKeyTagsText(ApiKeyModel context)
+        => string.Join("\n", context.Tags.Select(t => $"{t.Key} = {t.Value}"));
 
     private bool IsKeyVisible(ApiKeyModel context)
     {

--- a/Tharga.Team.Blazor/README.md
+++ b/Tharga.Team.Blazor/README.md
@@ -8,7 +8,7 @@ Team management Blazor components for multi-tenant applications. Works with both
 ## Components
 
 - **Team management** - `TeamSelector`, `TeamComponent`, `TeamDialog`, `InviteUserDialog`, `TeamInviteView`.
-- **API key management** - `ApiKeyView` for team-scoped API keys. Shows **Created** and **Last used** columns per key (`SystemApiKeyView` shows the same for system keys). Opt-in parameters: `ShowAuditLogButton` (per-row audit-log dialog), `ShowScopeOverrides` (Scopes column + create-card multi-select + Edit-Scopes dialog per row). "Last used" writes are throttled by `ApiKeyOptions.LastUsedThrottle` (default 1 min) to avoid a database write on every authenticated request.
+- **API key management** - `ApiKeyView` for team-scoped API keys. Shows **Created** and **Last used** columns per key (`SystemApiKeyView` shows the same for system keys). Also shows a **Tags** column (system-set key-value tags, displayed read-only via an `(i)` tooltip). Opt-in parameters: `ShowAuditLogButton` (per-row audit-log dialog), `ShowScopeOverrides` (Scopes column + create-card multi-select + Edit-Scopes dialog per row), `ChipTagKeys` (tag keys to render as chips in the row). "Last used" writes are throttled by `ApiKeyOptions.LastUsedThrottle` (default 1 min) to avoid a database write on every authenticated request.
 - **User management** - `UserProfileView`, `UsersView`.
 - **Authentication** - `LoginDisplay` with login/logout and team navigation.
 - **Claims augmentation** - `TeamClaimsAuthenticationStateProvider` adds `TeamKey`, `AccessLevel`, role, and scope claims. Compatible with all hosting models.

--- a/Tharga.Team.Service.Tests/ApiKeyAdministrationServiceTests.cs
+++ b/Tharga.Team.Service.Tests/ApiKeyAdministrationServiceTests.cs
@@ -274,6 +274,40 @@ public class ApiKeyAdministrationServiceTests
     }
 
     [Fact]
+    public async Task CreateKeyAsync_With_Tags_Persists_Them()
+    {
+        _apiKeyService.BuildApiKey(Arg.Any<string>(), Arg.Any<Func<string>>()).Returns("new-key");
+        _apiKeyService.Encrypt("new-key").Returns("new-hash");
+        _repository.AddAsync(Arg.Any<ApiKeyEntity>()).Returns(ci => Task.FromResult(ci.Arg<ApiKeyEntity>()));
+
+        var tags = new[] { new Tag("Type", "firewall"), new Tag("firewall.groupId", "ABC123") };
+        await _sut.CreateKeyAsync("team-1", "My Key", AccessLevel.Custom, tags: tags);
+
+        await _repository.Received(1).AddAsync(Arg.Is<ApiKeyEntity>(e =>
+            e.Tags != null
+            && e.Tags.Count == 2
+            && e.Tags[0].Key == "Type" && e.Tags[0].Value == "firewall"
+            && e.Tags[1].Key == "firewall.groupId" && e.Tags[1].Value == "ABC123"));
+    }
+
+    [Fact]
+    public async Task RefreshKeyAsync_Preserves_Tags()
+    {
+        var existing = CreateEntity("key-1", "old-hash", "team-1") with
+        {
+            Tags = new[] { new Tag("Type", "firewall") },
+        };
+        _repository.GetAsync("key-1").Returns(Task.FromResult(existing));
+        _apiKeyService.BuildApiKey(Arg.Any<string>(), Arg.Any<Func<string>>()).Returns("refreshed-key");
+        _apiKeyService.Encrypt("refreshed-key").Returns("refreshed-hash");
+
+        await _sut.RefreshKeyAsync("team-1", "key-1");
+
+        await _repository.Received(1).UpdateAsync("key-1", Arg.Is<ApiKeyEntity>(e =>
+            e.Tags != null && e.Tags.Count == 1 && e.Tags[0].Key == "Type" && e.Tags[0].Value == "firewall"));
+    }
+
+    [Fact]
     public async Task CreateKeyAsync_With_Custom_AccessLevel_Persists_Custom_And_Overrides()
     {
         // The headline #74 use case: a least-privilege machine key minted with Custom + a single

--- a/Tharga.Team.Service.Tests/ApiKeyAuthenticationHandlerTests.cs
+++ b/Tharga.Team.Service.Tests/ApiKeyAuthenticationHandlerTests.cs
@@ -147,7 +147,7 @@ public class ApiKeyAuthenticationHandlerTests
     }
 
     [Fact]
-    public async Task With_Valid_ApiKey_Without_Tags_Defaults_AccessLevel_To_Viewer()
+    public async Task With_Valid_ApiKey_Without_AccessLevel_Defaults_To_Viewer()
     {
         var apiKey = CreateApiKey("team-123");
         _apiKeyService.GetByApiKeyAsync("valid-key").Returns(Task.FromResult(apiKey));
@@ -255,13 +255,14 @@ public class ApiKeyAuthenticationHandlerTests
     }
 
     [Fact]
-    public async Task With_Valid_ApiKey_And_AccessLevel_Tag_Uses_Tag_Value()
+    public async Task With_NonEntity_ApiKey_Uses_Typed_AccessLevel()
     {
-        var tags = new Dictionary<string, string> { [TeamClaimTypes.AccessLevel] = "Viewer" };
-        var apiKey = CreateApiKey("team-123", tags: tags);
-        _apiKeyService.GetByApiKeyAsync("viewer-key").Returns(Task.FromResult(apiKey));
+        // A custom IApiKey (not ApiKeyEntity) resolves access level from its typed property, not Tags.
+        var apiKey = CreateApiKey("team-123");
+        apiKey.AccessLevel.Returns(AccessLevel.User);
+        _apiKeyService.GetByApiKeyAsync("typed-key").Returns(Task.FromResult(apiKey));
 
-        var context = CreateHttpContext("viewer-key");
+        var context = CreateHttpContext("typed-key");
         var handler = await CreateHandler(context);
 
         var result = await handler.AuthenticateAsync();
@@ -269,6 +270,6 @@ public class ApiKeyAuthenticationHandlerTests
         Assert.True(result.Succeeded);
         var accessLevelClaim = result.Principal.FindFirst(TeamClaimTypes.AccessLevel);
         Assert.NotNull(accessLevelClaim);
-        Assert.Equal("Viewer", accessLevelClaim.Value);
+        Assert.Equal("User", accessLevelClaim.Value);
     }
 }

--- a/Tharga.Team.Service.Tests/ApiKeyAuthenticationHandlerTests.cs
+++ b/Tharga.Team.Service.Tests/ApiKeyAuthenticationHandlerTests.cs
@@ -47,12 +47,12 @@ public class ApiKeyAuthenticationHandlerTests
         return context;
     }
 
-    private static IApiKey CreateApiKey(string teamKey, string name = "Test Key", Dictionary<string, string> tags = null)
+    private static IApiKey CreateApiKey(string teamKey, string name = "Test Key", IReadOnlyList<Tag> tags = null)
     {
         var apiKey = Substitute.For<IApiKey>();
         apiKey.TeamKey.Returns(teamKey);
         apiKey.Name.Returns(name);
-        apiKey.Tags.Returns(tags ?? new Dictionary<string, string>());
+        apiKey.Tags.Returns(tags ?? Array.Empty<Tag>());
         return apiKey;
     }
 
@@ -271,5 +271,42 @@ public class ApiKeyAuthenticationHandlerTests
         var accessLevelClaim = result.Principal.FindFirst(TeamClaimTypes.AccessLevel);
         Assert.NotNull(accessLevelClaim);
         Assert.Equal("User", accessLevelClaim.Value);
+    }
+
+    [Fact]
+    public async Task Tags_Emitted_As_Per_Entry_Claims_Including_Duplicate_Keys()
+    {
+        var apiKey = CreateApiKey("team-123", tags: new[]
+        {
+            new Tag("Type", "firewall"),
+            new Tag("Type", "PIM"),
+            new Tag("firewall.groupId", "ABC123"),
+        });
+        _apiKeyService.GetByApiKeyAsync("tagged-key").Returns(Task.FromResult(apiKey));
+
+        var context = CreateHttpContext("tagged-key");
+        var handler = await CreateHandler(context);
+
+        var result = await handler.AuthenticateAsync();
+
+        Assert.True(result.Succeeded);
+        var typeValues = result.Principal.FindAll("tag.Type").Select(c => c.Value).ToArray();
+        Assert.Equal(new[] { "firewall", "PIM" }, typeValues);
+        Assert.Equal("ABC123", result.Principal.FindFirst("tag.firewall.groupId")?.Value);
+    }
+
+    [Fact]
+    public async Task No_Tags_Emits_No_Tag_Claims()
+    {
+        var apiKey = CreateApiKey("team-123");
+        _apiKeyService.GetByApiKeyAsync("plain-key").Returns(Task.FromResult(apiKey));
+
+        var context = CreateHttpContext("plain-key");
+        var handler = await CreateHandler(context);
+
+        var result = await handler.AuthenticateAsync();
+
+        Assert.True(result.Succeeded);
+        Assert.DoesNotContain(result.Principal.Claims, c => c.Type.StartsWith(TeamClaimTypes.TagPrefix));
     }
 }

--- a/Tharga.Team.Service.Tests/ApiKeyEntityTagsSerializationTests.cs
+++ b/Tharga.Team.Service.Tests/ApiKeyEntityTagsSerializationTests.cs
@@ -1,0 +1,76 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using Tharga.Team;
+
+namespace Tharga.Team.Service.Tests;
+
+/// <summary>
+/// Guards the #75 type change: <c>ApiKeyEntity.Tags</c> moved from <c>Dictionary&lt;string,string&gt;</c>
+/// to <c>IReadOnlyList&lt;Tag&gt;</c>. Verifies the Bson serializer round-trips it (the driver must map
+/// the read-only interface back to a concrete list), including duplicate keys.
+/// </summary>
+public class ApiKeyEntityTagsSerializationTests
+{
+    [Fact]
+    public void Tags_RoundTrip_Through_Bson_Preserving_Order_And_Duplicate_Keys()
+    {
+        var entity = new ApiKeyEntity
+        {
+            Id = ObjectId.GenerateNewId(),
+            Key = "key-1",
+            Name = "Test",
+            ApiKeyHash = "hash",
+            TeamKey = "team-1",
+            Tags = new[]
+            {
+                new Tag("Type", "firewall"),
+                new Tag("Type", "PIM"),
+                new Tag("firewall.groupId", "ABC123"),
+            },
+        };
+
+        var bson = entity.ToBson();
+        var back = BsonSerializer.Deserialize<ApiKeyEntity>(bson);
+
+        Assert.NotNull(back.Tags);
+        Assert.Equal(3, back.Tags.Count);
+        Assert.Equal(new[] { "firewall", "PIM" }, back.Tags.Where(t => t.Key == "Type").Select(t => t.Value));
+        Assert.Equal("ABC123", back.Tags.Single(t => t.Key == "firewall.groupId").Value);
+    }
+
+    [Fact]
+    public void Legacy_Document_Tags_Deserialize_As_Null_Without_Throwing()
+    {
+        // Simulates a pre-#75 document where Tags was an (empty) Dictionary<string,string> => BSON document.
+        var doc = new BsonDocument
+        {
+            { "_id", ObjectId.GenerateNewId() },
+            { "Key", "legacy-1" },
+            { "Name", "Legacy" },
+            { "ApiKeyHash", "hash" },
+            { "TeamKey", "team-1" },
+            { "Tags", new BsonDocument() },
+        };
+
+        var back = BsonSerializer.Deserialize<ApiKeyEntity>(doc);
+
+        Assert.Null(back.Tags);
+    }
+
+    [Fact]
+    public void Null_Tags_RoundTrip_As_Null()
+    {
+        var entity = new ApiKeyEntity
+        {
+            Id = ObjectId.GenerateNewId(),
+            Key = "key-2",
+            Name = "Test",
+            ApiKeyHash = "hash",
+            TeamKey = "team-1",
+        };
+
+        var back = BsonSerializer.Deserialize<ApiKeyEntity>(entity.ToBson());
+
+        Assert.Null(back.Tags);
+    }
+}

--- a/Tharga.Team.Service.Tests/ApiKeyIdClaimTests.cs
+++ b/Tharga.Team.Service.Tests/ApiKeyIdClaimTests.cs
@@ -40,7 +40,7 @@ public class ApiKeyIdClaimTests
         key.Key.Returns("11111111-1111-1111-1111-111111111111");
         key.TeamKey.Returns("team-1");
         key.Name.Returns("team-key");
-        key.Tags.Returns(new Dictionary<string, string>());
+        key.Tags.Returns(Array.Empty<Tag>());
         _apiKeyService.GetByApiKeyAsync("raw").Returns(key);
 
         var handler = await CreateHandler(CreateHttpContext("raw"));
@@ -60,7 +60,7 @@ public class ApiKeyIdClaimTests
         key.TeamKey.Returns((string)null);
         key.Name.Returns("system-key");
         key.SystemScopes.Returns(new[] { "mcp:discover" });
-        key.Tags.Returns(new Dictionary<string, string>());
+        key.Tags.Returns(Array.Empty<Tag>());
         _apiKeyService.GetByApiKeyAsync("raw").Returns(key);
 
         var handler = await CreateHandler(CreateHttpContext("raw"));

--- a/Tharga.Team.Service.Tests/ApiKeyManagementServiceTests.cs
+++ b/Tharga.Team.Service.Tests/ApiKeyManagementServiceTests.cs
@@ -1,0 +1,18 @@
+using Tharga.Team;
+
+namespace Tharga.Team.Service.Tests;
+
+public class ApiKeyManagementServiceTests
+{
+    [Fact]
+    public async Task CreateKeyAsync_Forwards_Tags_To_Inner()
+    {
+        var inner = Substitute.For<IApiKeyAdministrationService>();
+        var sut = new ApiKeyManagementService(inner);
+        var tags = new[] { new Tag("Type", "firewall") };
+
+        await sut.CreateKeyAsync("team-1", "My Key", AccessLevel.Custom, tags: tags);
+
+        await inner.Received(1).CreateKeyAsync("team-1", "My Key", AccessLevel.Custom, null, null, null, tags);
+    }
+}

--- a/Tharga.Team.Service.Tests/SystemApiKeyAuthenticationHandlerTests.cs
+++ b/Tharga.Team.Service.Tests/SystemApiKeyAuthenticationHandlerTests.cs
@@ -40,7 +40,7 @@ public class SystemApiKeyAuthenticationHandlerTests
         key.TeamKey.Returns((string)null);
         key.Name.Returns(name);
         key.SystemScopes.Returns(scopes);
-        key.Tags.Returns(new Dictionary<string, string>());
+        key.Tags.Returns(Array.Empty<Tag>());
         return key;
     }
 
@@ -82,7 +82,7 @@ public class SystemApiKeyAuthenticationHandlerTests
         var teamKey = Substitute.For<IApiKey>();
         teamKey.TeamKey.Returns("team-1");
         teamKey.Name.Returns("team-bound");
-        teamKey.Tags.Returns(new Dictionary<string, string>());
+        teamKey.Tags.Returns(Array.Empty<Tag>());
         _apiKeyService.GetByApiKeyAsync("raw").Returns(teamKey);
 
         var ctx = CreateHttpContext("raw");

--- a/Tharga.Team.Service/ApiKeyAdministrationService.cs
+++ b/Tharga.Team.Service/ApiKeyAdministrationService.cs
@@ -110,7 +110,7 @@ public class ApiKeyAdministrationService : IApiKeyAdministrationService
     }
 
     /// <inheritdoc />
-    public async Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null)
+    public async Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null, IReadOnlyList<Tag> tags = null)
     {
         expiryDate ??= GetDefaultExpiryDate();
 
@@ -121,7 +121,7 @@ public class ApiKeyAdministrationService : IApiKeyAdministrationService
                 throw new InvalidOperationException($"Expiry date cannot exceed {_options.MaxExpiryDays} days from now.");
         }
 
-        var entity = BuildKey(teamKey, name, new Dictionary<string, string>(), accessLevel, roles, scopeOverrides, expiryDate);
+        var entity = BuildKey(teamKey, name, tags, accessLevel, roles, scopeOverrides, expiryDate);
         var created = await _repository.AddAsync(entity);
 
         if (_options.AutoLockKeys)
@@ -254,7 +254,7 @@ public class ApiKeyAdministrationService : IApiKeyAdministrationService
             : null;
     }
 
-    private ApiKeyEntity BuildKey(string teamKey, string name, Dictionary<string, string> tags, AccessLevel accessLevel, string[] roles, string[] scopeOverrides, DateTime? expiryDate)
+    private ApiKeyEntity BuildKey(string teamKey, string name, IReadOnlyList<Tag> tags, AccessLevel accessLevel, string[] roles, string[] scopeOverrides, DateTime? expiryDate)
     {
         var apiKey = _apiKeyService.BuildApiKey(teamKey, () => StringExtension.GetRandomString(24, 32));
         var encryptedApiKey = _apiKeyService.Encrypt(apiKey);
@@ -288,7 +288,6 @@ public class ApiKeyAdministrationService : IApiKeyAdministrationService
             ApiKey = apiKey,
             ApiKeyPrefix = GetPrefix(apiKey),
             TeamKey = null,
-            Tags = new Dictionary<string, string>(),
             ApiKeyHash = encryptedApiKey,
             SystemScopes = scopes,
             ExpiryDate = expiryDate,

--- a/Tharga.Team.Service/ApiKeyAuthenticationHandler.cs
+++ b/Tharga.Team.Service/ApiKeyAuthenticationHandler.cs
@@ -134,18 +134,11 @@ public class ApiKeyAuthenticationHandler : AuthenticationHandler<AuthenticationS
             return (al, roles, overrides);
         }
 
-        var accessLevelStr = key.Tags.TryGetValue(TeamClaimTypes.AccessLevel, out var level)
-            ? level
-            : AccessLevel.Viewer.ToString();
-
-        var accessLevel = Enum.TryParse<AccessLevel>(accessLevelStr, out var parsed)
-            ? parsed
-            : AccessLevel.Viewer;
-
-        var roleStr = key.Tags.TryGetValue("TenantRoles", out var r)
-            ? r.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            : Array.Empty<string>();
-
-        return (accessLevel, roleStr, Array.Empty<string>());
+        // Non-entity IApiKey (custom store): read the typed properties directly. (These superseded
+        // the old Tags["AccessLevel"]/["TenantRoles"] fallback, which also ignored ScopeOverrides.)
+        return (
+            key.AccessLevel ?? AccessLevel.Viewer,
+            key.Roles ?? Array.Empty<string>(),
+            key.ScopeOverrides ?? Array.Empty<string>());
     }
 }

--- a/Tharga.Team.Service/ApiKeyAuthenticationHandler.cs
+++ b/Tharga.Team.Service/ApiKeyAuthenticationHandler.cs
@@ -94,6 +94,11 @@ public class ApiKeyAuthenticationHandler : AuthenticationHandler<AuthenticationS
                     claims.Add(new Claim(TeamClaimTypes.Scope, scope));
                 }
             }
+
+            foreach (var tag in key.Tags ?? Array.Empty<Tag>())
+            {
+                claims.Add(new Claim($"{TeamClaimTypes.TagPrefix}{tag.Key}", tag.Value));
+            }
         }
 
         var identity = new ClaimsIdentity(claims, Scheme.Name);

--- a/Tharga.Team.Service/ApiKeyEntity.cs
+++ b/Tharga.Team.Service/ApiKeyEntity.cs
@@ -31,8 +31,9 @@ public record ApiKeyEntity : EntityBase, IApiKey
     public string CreatedBy { get; init; }
 
     /// <inheritdoc />
-    [BsonIgnoreIfDefault]
-    public Dictionary<string, string> Tags { get; init; } = new();
+    [BsonIgnoreIfNull]
+    [BsonSerializer(typeof(TagListBsonSerializer))]
+    public IReadOnlyList<Tag> Tags { get; init; }
 
     /// <summary>Hashed value of the API key used for verification.</summary>
     public required string ApiKeyHash { get; init; }

--- a/Tharga.Team.Service/ApiKeyManagementService.cs
+++ b/Tharga.Team.Service/ApiKeyManagementService.cs
@@ -20,7 +20,7 @@ public class ApiKeyManagementService : IApiKeyManagementService
     }
 
     public IAsyncEnumerable<IApiKey> GetKeysAsync(string teamKey) => _inner.GetKeysAsync(teamKey);
-    public Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null) => _inner.CreateKeyAsync(teamKey, name, accessLevel, roles, scopeOverrides, expiryDate);
+    public Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null, IReadOnlyList<Tag> tags = null) => _inner.CreateKeyAsync(teamKey, name, accessLevel, roles, scopeOverrides, expiryDate, tags);
     public Task<IApiKey> RefreshKeyAsync(string teamKey, string key) => _inner.RefreshKeyAsync(teamKey, key);
     public Task LockKeyAsync(string teamKey, string key) => _inner.LockKeyAsync(teamKey, key);
     public Task DeleteKeyAsync(string teamKey, string key) => _inner.DeleteKeyAsync(teamKey, key);

--- a/Tharga.Team.Service/ApiKeyRepository.cs
+++ b/Tharga.Team.Service/ApiKeyRepository.cs
@@ -1,4 +1,6 @@
+using MongoDB.Bson;
 using MongoDB.Driver;
+using Tharga.MongoDB.Disk;
 
 namespace Tharga.Team.Service;
 
@@ -69,5 +71,19 @@ internal class ApiKeyRepository : IApiKeyRepository
     public async Task PurgeExpiredAsync()
     {
         await _collection.DeleteManyAsync(x => x.ExpiryDate != null && x.ExpiryDate < DateTime.UtcNow);
+    }
+
+    public Task<long> CleanLegacyTagsAsync()
+    {
+        // Before #75, Tags was a Dictionary<string,string> persisted as a BSON document. Unset that
+        // legacy field where it is still an object (not the new array), so those documents load again.
+        // Runs server-side via the raw collection — it must not deserialize ApiKeyEntity (which would throw).
+        var filter = new BsonDocument("Tags", new BsonDocument("$type", "object"));
+        var update = new BsonDocument("$unset", new BsonDocument("Tags", 1));
+        return _collection.ExecuteAsync(async collection =>
+        {
+            var result = await collection.UpdateManyAsync(filter, update);
+            return result.IsModifiedCountAvailable ? result.ModifiedCount : result.MatchedCount;
+        }, Operation.Update);
     }
 }

--- a/Tharga.Team.Service/Audit/AuditingApiKeyServiceDecorator.cs
+++ b/Tharga.Team.Service/Audit/AuditingApiKeyServiceDecorator.cs
@@ -30,12 +30,12 @@ public class AuditingApiKeyServiceDecorator : IApiKeyAdministrationService
 
     // Mutation operations — log audit entries
 
-    public async Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null)
+    public async Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null, IReadOnlyList<Tag> tags = null)
     {
         var sw = Stopwatch.StartNew();
         try
         {
-            var result = await _inner.CreateKeyAsync(teamKey, name, accessLevel, roles, scopeOverrides, expiryDate);
+            var result = await _inner.CreateKeyAsync(teamKey, name, accessLevel, roles, scopeOverrides, expiryDate, tags);
             sw.Stop();
             Log("create", nameof(CreateKeyAsync), sw.ElapsedMilliseconds, true, teamKey: teamKey);
             return result;

--- a/Tharga.Team.Service/IApiKeyRepository.cs
+++ b/Tharga.Team.Service/IApiKeyRepository.cs
@@ -33,4 +33,12 @@ public interface IApiKeyRepository : IRepository
 
     /// <summary>Deletes all expired API key entities.</summary>
     Task PurgeExpiredAsync();
+
+    /// <summary>
+    /// One-time migration: removes the legacy <c>Tags</c> field from documents where it is still stored as a
+    /// BSON document (the pre-#75 <c>Dictionary&lt;string,string&gt;</c> representation). Runs server-side and
+    /// returns the number of documents cleaned. Safe to run repeatedly. Reading is already tolerant of the
+    /// legacy shape; this just purges it permanently.
+    /// </summary>
+    Task<long> CleanLegacyTagsAsync();
 }

--- a/Tharga.Team.Service/TagListBsonSerializer.cs
+++ b/Tharga.Team.Service/TagListBsonSerializer.cs
@@ -1,0 +1,58 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+using Tharga.Team;
+
+namespace Tharga.Team.Service;
+
+/// <summary>
+/// Serializer for an API key's <c>Tags</c> (a list of <see cref="Tag"/>). Tolerates the legacy
+/// representation: before #75, <c>Tags</c> was a <c>Dictionary&lt;string,string&gt;</c> persisted as a
+/// BSON <em>document</em> (always empty in practice). Reading such a document as the new array type
+/// would throw; this serializer maps a legacy document (or null) to <c>null</c> and otherwise reads a
+/// normal array. New writes are always arrays. Pair with <c>IApiKeyRepository.CleanLegacyTagsAsync</c>
+/// to purge the legacy field permanently.
+/// </summary>
+internal sealed class TagListBsonSerializer : SerializerBase<IReadOnlyList<Tag>>
+{
+    private static readonly IBsonSerializer<Tag> TagSerializer = BsonSerializer.LookupSerializer<Tag>();
+
+    public override IReadOnlyList<Tag> Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+    {
+        var reader = context.Reader;
+        switch (reader.GetCurrentBsonType())
+        {
+            case BsonType.Null:
+                reader.ReadNull();
+                return null;
+            case BsonType.Document:
+                // Legacy Dictionary<string,string> (empty) — treat as no tags.
+                reader.SkipValue();
+                return null;
+            case BsonType.Array:
+                var list = new List<Tag>();
+                reader.ReadStartArray();
+                while (reader.ReadBsonType() != BsonType.EndOfDocument)
+                    list.Add(TagSerializer.Deserialize(context));
+                reader.ReadEndArray();
+                return list;
+            default:
+                throw new FormatException($"Cannot deserialize Tags from BSON type '{reader.GetCurrentBsonType()}'.");
+        }
+    }
+
+    public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, IReadOnlyList<Tag> value)
+    {
+        var writer = context.Writer;
+        if (value == null)
+        {
+            writer.WriteNull();
+            return;
+        }
+
+        writer.WriteStartArray();
+        foreach (var tag in value)
+            TagSerializer.Serialize(context, tag);
+        writer.WriteEndArray();
+    }
+}

--- a/Tharga.Team/IApiKey.cs
+++ b/Tharga.Team/IApiKey.cs
@@ -23,8 +23,12 @@ public interface IApiKey
     /// <summary>User who created this key (identity/display name). Null if not recorded.</summary>
     string CreatedBy { get; }
 
-    /// <summary>Arbitrary key-value metadata associated with this API key.</summary>
-    Dictionary<string, string> Tags { get; }
+    /// <summary>
+    /// System-set key-value tags on this API key. A list (not a map), so a key may repeat.
+    /// Set only at creation via the service; immutable thereafter and not editable from the UI.
+    /// Each tag is surfaced as a <c>tag.{Key}</c> claim on the authenticated principal.
+    /// </summary>
+    IReadOnlyList<Tag> Tags { get; }
 
     /// <summary>Access level assigned to this API key. Null defaults to Administrator.</summary>
     AccessLevel? AccessLevel { get; }

--- a/Tharga.Team/IApiKeyAdministrationService.cs
+++ b/Tharga.Team/IApiKeyAdministrationService.cs
@@ -11,8 +11,8 @@ public interface IApiKeyAdministrationService
     /// <summary>Returns all API keys for the specified team, creating default keys if fewer than AutoKeyCount exist.</summary>
     IAsyncEnumerable<IApiKey> GetKeysAsync(string teamKey);
 
-    /// <summary>Creates a new API key with the specified settings (advanced mode).</summary>
-    Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null);
+    /// <summary>Creates a new API key with the specified settings (advanced mode). <paramref name="tags"/> are system-set key-value tags, settable only here (not from the UI) and immutable thereafter.</summary>
+    Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null, IReadOnlyList<Tag> tags = null);
 
     /// <summary>Generates a new API key value for an existing key entry. Returns the entity with the raw key visible once.</summary>
     Task<IApiKey> RefreshKeyAsync(string teamKey, string key);

--- a/Tharga.Team/IApiKeyManagementService.cs
+++ b/Tharga.Team/IApiKeyManagementService.cs
@@ -9,7 +9,7 @@ public interface IApiKeyManagementService
     IAsyncEnumerable<IApiKey> GetKeysAsync(string teamKey);
 
     [RequireScope(ApiKeyScopes.Manage)]
-    Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null);
+    Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null, IReadOnlyList<Tag> tags = null);
 
     [RequireScope(ApiKeyScopes.Manage)]
     Task<IApiKey> RefreshKeyAsync(string teamKey, string key);

--- a/Tharga.Team/README.md
+++ b/Tharga.Team/README.md
@@ -21,7 +21,8 @@ Domain models, service abstractions, and authorization primitives for multi-tena
 
 ### Authorization
 - `AccessLevel` enum - Owner, Administrator, User, Viewer, Custom. `Custom` grants no inherited base scopes (effective scopes = roles ∪ scope overrides only) for least-privilege keys/members.
-- `TeamClaimTypes` - Claim type constants (`TeamKey`, `AccessLevel`, `Scope`).
+- `Tag` record - System-set key-value tag on an API key (a list, so a key may repeat). Set at creation only; surfaced as a `tag.{Key}` claim on the authenticated principal.
+- `TeamClaimTypes` - Claim type constants (`TeamKey`, `AccessLevel`, `Scope`, `TagPrefix`).
 - `IScopeRegistry` / `ScopeRegistry` - Register and resolve scopes per access level.
 - `ITenantRoleRegistry` / `TenantRoleRegistry` - Register tenant roles with associated scopes.
 - `RequireAccessLevelAttribute` / `RequireScopeAttribute` - Declarative authorization on service methods.

--- a/Tharga.Team/Tag.cs
+++ b/Tharga.Team/Tag.cs
@@ -1,0 +1,8 @@
+namespace Tharga.Team;
+
+/// <summary>
+/// A system-set key-value tag on an API key. Tags are a list (not a map), so the same
+/// <see cref="Key"/> may appear more than once (e.g. a combination key tagged with multiple
+/// types). Each tag is surfaced as a <c>tag.{Key}</c> claim on the authenticated principal.
+/// </summary>
+public record Tag(string Key, string Value);

--- a/Tharga.Team/TeamClaimTypes.cs
+++ b/Tharga.Team/TeamClaimTypes.cs
@@ -19,4 +19,7 @@ public static class TeamClaimTypes
 
     /// <summary>Claim type carrying the stable identifier of the API key used to authenticate (the <c>IApiKey.Key</c> Guid string).</summary>
     public const string ApiKeyId = "ApiKeyId";
+
+    /// <summary>Prefix for per-tag claims emitted from an API key's <c>Tags</c>. A tag with key <c>K</c> becomes a claim of type <c>tag.K</c>. Multiple claims with the same type may be present.</summary>
+    public const string TagPrefix = "tag.";
 }

--- a/docs/implementation-guide.md
+++ b/docs/implementation-guide.md
@@ -490,7 +490,7 @@ public class MyTeamService : TeamServiceRepositoryBase<TeamEntity, TeamMember>
 | `<TeamComponent />` | Full team management (create, rename, delete, members) |
 | `<TeamInviteView />` | Pending invitation view |
 | `<UsersView />` | Admin user list |
-| `<ApiKeyView />` | API key management (requires Step 5). Shows **Created** and **Last used** columns per key. Opt-in `[Parameter]` flags: `ShowAuditLogButton`, `ShowScopeOverrides` (Scopes column + create-card multi-select + Edit-Scopes dialog per row) |
+| `<ApiKeyView />` | API key management (requires Step 5). Shows **Created** and **Last used** columns per key, and a **Tags** column (chips for keys in `ChipTagKeys`, plus an `(i)` tooltip of all tags). Opt-in `[Parameter]` flags: `ShowAuditLogButton`, `ShowScopeOverrides` (Scopes column + create-card multi-select + Edit-Scopes dialog per row), `ChipTagKeys` |
 | `<AuditLogView />` | Audit log viewer (requires Step 8) |
 | `Roles.TeamMember` | Role claim added to authenticated team members |
 | `Roles.Developer` | Role for developer-only UI sections |
@@ -638,6 +638,21 @@ builder.Services.AddAuthentication()
 ```razor
 @using Tharga.Team.Service
 ```
+
+### System-set tags
+
+API keys can carry **system-set tags** — a key-value list (`IReadOnlyList<Tag>`, `record Tag(string Key, string Value)`) set by backend code at creation. Tags are **backend-only**: there's a `tags` parameter on `CreateKeyAsync`, no mutation API, and no input in the `ApiKeyView` create card — so an operator can't add or re-point them from the UI.
+
+```csharp
+await apiKeyManagementService.CreateKeyAsync(
+    teamKey, "Firewall opener", AccessLevel.Custom,
+    scopeOverrides: new[] { "firewall:open" },
+    tags: new[] { new Tag("Type", "firewall"), new Tag("firewall.groupId", "ABC123") });
+```
+
+- **Surfaced as claims.** Each tag becomes a `tag.{Key}` claim on the authenticated principal (`TeamClaimTypes.TagPrefix = "tag."`) — no DB round-trip to read a key's binding. Because it's a *list*, a key may carry the same key twice (e.g. `Type=firewall` + `Type=PIM`), producing two `tag.Type` claims; read them with `user.FindAll("tag.Type")`.
+- **Displayed read-only.** `ApiKeyView` shows all tags in an `(i)` tooltip; pass `ChipTagKeys` to render selected keys as chips (e.g. `ChipTagKeys="@(new[] { "Type" })"`).
+- **Legacy data.** Pre-tags keys stored an empty `Tags` document; reads tolerate this automatically (it deserializes as no tags). To purge the legacy field, call `IApiKeyRepository.CleanLegacyTagsAsync()` once (server-side, safe to repeat).
 
 ### Verification
 


### PR DESCRIPTION
## System-set API key tags

API keys can now carry **system-set key-value tags** — metadata set by backend code at creation, surfaced as claims on the authenticated principal and shown read-only in `ApiKeyView`. This lets a key be bound to a domain object (e.g. `firewall.groupId=ABC123`) and/or categorised (e.g. `Type=firewall`) without a side-collection.

Closes #75.

### What's new
- **`Tag` type + `IApiKey.Tags`.** `Tags` is now `IReadOnlyList<Tag>` (`record Tag(string Key, string Value)`) — a **list**, so a key may carry the same key more than once (e.g. a combination key tagged `Type=firewall` + `Type=PIM`).
- **Backend-only, immutable.** A `tags` parameter on `CreateKeyAsync` (admin + management service). There is **no** mutation API and **no** tags input in the `ApiKeyView` create card, so tags can't be added or re-pointed from the UI — the minting code stays the sole writer. `RefreshKeyAsync` preserves them.
- **Surfaced as claims.** Each tag becomes a `tag.{Key}` claim (`TeamClaimTypes.TagPrefix = "tag."`), so consumers read a key's binding with no DB round-trip. Duplicate keys produce multiple claims: `user.FindAll("tag.Type")`.
- **Read-only display.** `ApiKeyView` shows all tags in an `(i)` tooltip; the new `ChipTagKeys` parameter renders selected keys as chips in the row.

### How to use
```csharp
await apiKeyManagementService.CreateKeyAsync(
    teamKey, "Firewall opener", AccessLevel.Custom,
    scopeOverrides: new[] { "firewall:open" },
    tags: new[] { new Tag("Type", "firewall"), new Tag("firewall.groupId", "ABC123") });
```
```razor
<ApiKeyView ShowScopeOverrides="true" ChipTagKeys="@(new[] { "Type" })" />
```

### Upgrade / data note (minor, but a type change)
`IApiKey.Tags` changed from `Dictionary<string,string>` to `IReadOnlyList<Tag>`. Pre-existing keys stored an empty `Tags` document; **reads tolerate this automatically** (a custom serializer maps the legacy document to "no tags"), so no migration is required. To purge the legacy field permanently, call `IApiKeyRepository.CleanLegacyTagsAsync()` once (server-side, safe to repeat). The internal non-entity `ResolveKeyDetails` fallback was also switched from `Tags["AccessLevel"]`/`["TenantRoles"]` to the typed `IApiKey` properties.

### Tests & sample
9 new tests (per-entry/duplicate-key claims, create persists / refresh preserves, management forwarding, Bson round-trip + legacy-document tolerance, `ChipTagKeys` parameter). The sample app (`/api-keys`) gains a "Create special API key" form demonstrating `AccessLevel.Custom` + scope overrides + tags. Docs + READMEs updated. Version bumped 2.1 → 2.2.
