### PR TITLE
API key 'Created by' + context-menu row actions

### DIFF
--- a/Tharga.Platform.Sample/Components/Pages/ApiKeysPage.razor
+++ b/Tharga.Platform.Sample/Components/Pages/ApiKeysPage.razor
@@ -2,6 +2,11 @@
 @rendermode InteractiveServer
 @attribute [Authorize]
 @using Microsoft.AspNetCore.Authorization
+@using Microsoft.Extensions.DependencyInjection
+@using Tharga.Team
+@inject ITeamStateService TeamStateService
+@inject IServiceProvider ServiceProvider
+@inject NotificationService NotificationService
 
 <PageTitle>API Keys</PageTitle>
 
@@ -23,8 +28,20 @@
     </RadzenStack>
 </RadzenStack>
 
+@* One-click demo: mints a team API key carrying a system-set Tag ("Type"), which renders as a chip below. *@
+<RadzenButton Text="Create tagged key" Icon="vpn_key" ButtonStyle="ButtonStyle.Secondary"
+              Click="@CreateTaggedKeyAsync" Disabled="@(_apiKeyManagementService == null)" class="rz-mb-3" />
+
+@if (_createdKey != null)
+{
+    <RadzenAlert AlertStyle="AlertStyle.Success" ShowIcon="true" Variant="Variant.Flat" class="rz-mb-3">
+        Created <b>@_createdKey.Name</b> (tag <code>Type=demo</code>) — copy the value now (shown once):
+        <pre style="white-space:pre-wrap; margin:.5rem 0 0">@_createdKey.ApiKey</pre>
+    </RadzenAlert>
+}
+
 @* ShowTags omitted → auto: the Tags column appears only when at least one key has tags. *@
-<ApiKeyView ShowAuditLogButton="true" ShowScopeTooltip="_showScopeTooltip"
+<ApiKeyView @key="_reloadToken" ShowAuditLogButton="true" ShowScopeTooltip="_showScopeTooltip"
             ShowScopeOverrides="_showScopeOverrides" ShowRoles="_showRoles" ShowLastUsed="_showLastUsed"
             ShowExpiryDatePicker="_showExpiryDatePicker" ChipTagKeys="@(new[] { "Type" })" />
 
@@ -34,4 +51,28 @@
     private bool _showRoles;
     private bool _showLastUsed = true;
     private bool _showExpiryDatePicker;
+
+    private IApiKeyManagementService _apiKeyManagementService;
+    private IApiKey _createdKey;
+    private Guid _reloadToken = Guid.NewGuid();
+
+    protected override void OnInitialized()
+        => _apiKeyManagementService = ServiceProvider.GetService<IApiKeyManagementService>();
+
+    private async Task CreateTaggedKeyAsync()
+    {
+        var team = await TeamStateService.GetSelectedTeamAsync();
+        if (team?.Key == null)
+        {
+            NotificationService.Notify(NotificationSeverity.Warning, "No team selected.");
+            return;
+        }
+
+        var name = $"Tagged key {Guid.NewGuid().ToString("N")[..6]}";
+        _createdKey = await _apiKeyManagementService.CreateKeyAsync(
+            team.Key, name, AccessLevel.User, tags: new[] { new Tag("Type", "demo") });
+
+        _reloadToken = Guid.NewGuid(); // force ApiKeyView to reload so the new key shows in the list
+        NotificationService.Notify(NotificationSeverity.Success, $"Created '{name}' with tag Type=demo.");
+    }
 }

--- a/Tharga.Platform.Sample/Program.cs
+++ b/Tharga.Platform.Sample/Program.cs
@@ -23,6 +23,7 @@ builder.AddThargaPlatform(o =>
     o.Blazor.AutoCreateFirstTeam = false;
     o.Blazor.AllowTeamCreation = true;
     o.Blazor.AddClaimsEnricher<DeveloperRoleEnricher>();
+    o.Blazor.Consent.ShowToggle = true;
 
     // Advanced mode unlocks the full API key UI (access level, roles, scope overrides, tags).
     o.ApiKey.AdvancedMode = true;

--- a/Tharga.Team.Blazor/Features/Api/ApiKeyModel.cs
+++ b/Tharga.Team.Blazor/Features/Api/ApiKeyModel.cs
@@ -13,6 +13,7 @@ public record ApiKeyModel
     public string[] ScopeOverrides { get; init; }
     public DateTime? ExpiryDate { get; init; }
     public DateTime? CreatedAt { get; init; }
+    public string CreatedBy { get; init; }
     public DateTime? LastUsedAt { get; init; }
     public IReadOnlyList<Tag> Tags { get; init; } = Array.Empty<Tag>();
     public bool IsExpired => ExpiryDate.HasValue && ExpiryDate < DateTime.UtcNow;

--- a/Tharga.Team.Blazor/Features/Api/ApiKeyView.razor
+++ b/Tharga.Team.Blazor/Features/Api/ApiKeyView.razor
@@ -9,6 +9,7 @@
 @inject IJSRuntime Js
 @inject DialogService DialogService
 @inject NotificationService NotificationService
+@inject ContextMenuService ContextMenuService
 
 @if (_apiKeyServiceMissing)
 {
@@ -114,47 +115,10 @@ else
                     }
                 </Template>
             </RadzenDataGridColumn>
-            <RadzenDataGridColumn Width="170px" TextAlign="TextAlign.Right">
+            <RadzenDataGridColumn Width="56px" TextAlign="TextAlign.Right">
                 <Template>
-                    @{
-                        var hasValue = !string.IsNullOrEmpty(context.ApiKey);
-                        var showEdit = (ShowScopeOverrides && _scopeRegistry != null) || (ShowRoles && _tenantRoleRegistry != null);
-                    }
-                    <RadzenSplitButton Text="@(hasValue ? "Copy" : "")"
-                                       Icon="@(hasValue ? "content_copy" : "more_vert")"
-                                       Click="@(args => OnRowActionAsync(context, args))">
-                        <ChildContent>
-                            @* @if (hasValue)
-                            {
-                                <RadzenSplitButtonItem Text="Copy" Icon="content_copy" Value="copy" />
-                            } *@
-                            @if (hasValue && context.VisibleKey == _apiKeyMask)
-                            {
-                                <RadzenSplitButtonItem Text="Show value" Icon="visibility" Value="show" />
-                            }
-                            @if (hasValue && context.VisibleKey != _apiKeyMask)
-                            {
-                                <RadzenSplitButtonItem Text="Hide value" Icon="visibility_off" Value="hide" />
-                            }
-                            @if (ShowAuditLogButton)
-                            {
-                                <RadzenSplitButtonItem Text="Audit log" Icon="manage_search" Value="audit" />
-                            }
-                            @if (showEdit)
-                            {
-                                <RadzenSplitButtonItem Text="Edit roles & scopes" Icon="tune" Value="edit" />
-                            }
-                            @if (hasValue)
-                            {
-                                <RadzenSplitButtonItem Text="Lock" Icon="lock" Value="lock" />
-                            }
-                            <RadzenSplitButtonItem Text="Refresh" Icon="refresh" Value="refresh" />
-                            @if (_options.AdvancedMode)
-                            {
-                                <RadzenSplitButtonItem Text="Delete" Icon="delete" Value="delete" />
-                            }
-                        </ChildContent>
-                    </RadzenSplitButton>
+                    <RadzenButton Icon="more_vert" Variant="Variant.Flat" ButtonStyle="ButtonStyle.Base"
+                                  Click="@(args => OpenRowMenu(args, context))" title="Actions" />
                 </Template>
             </RadzenDataGridColumn>
         </Columns>
@@ -417,10 +381,30 @@ else
         return !string.IsNullOrEmpty(context.VisibleKey) && context.VisibleKey != _apiKeyMask;
     }
 
-    private async Task OnRowActionAsync(ApiKeyModel context, RadzenSplitButtonItem item)
+    private void OpenRowMenu(MouseEventArgs args, ApiKeyModel context)
     {
-        // item is null when the primary button is clicked: copy when there's a value, otherwise no-op.
-        var action = item?.Value ?? (string.IsNullOrEmpty(context.ApiKey) ? null : "copy");
+        var hasValue = !string.IsNullOrEmpty(context.ApiKey);
+        var showEdit = (ShowScopeOverrides && _scopeRegistry != null) || (ShowRoles && _tenantRoleRegistry != null);
+
+        var items = new List<ContextMenuItem>();
+        if (hasValue) items.Add(new ContextMenuItem { Text = "Copy", Icon = "content_copy", Value = "copy" });
+        if (hasValue && context.VisibleKey == _apiKeyMask) items.Add(new ContextMenuItem { Text = "Show value", Icon = "visibility", Value = "show" });
+        if (hasValue && context.VisibleKey != _apiKeyMask) items.Add(new ContextMenuItem { Text = "Hide value", Icon = "visibility_off", Value = "hide" });
+        if (ShowAuditLogButton) items.Add(new ContextMenuItem { Text = "Audit log", Icon = "manage_search", Value = "audit" });
+        if (showEdit) items.Add(new ContextMenuItem { Text = "Edit roles & scopes", Icon = "tune", Value = "edit" });
+        if (hasValue) items.Add(new ContextMenuItem { Text = "Lock", Icon = "lock", Value = "lock" });
+        items.Add(new ContextMenuItem { Text = "Refresh", Icon = "refresh", Value = "refresh" });
+        if (_options.AdvancedMode) items.Add(new ContextMenuItem { Text = "Delete", Icon = "delete", Value = "delete" });
+
+        ContextMenuService.Open(args, items, async e =>
+        {
+            ContextMenuService.Close();
+            await OnRowActionAsync(context, e.Value as string);
+        });
+    }
+
+    private async Task OnRowActionAsync(ApiKeyModel context, string action)
+    {
         switch (action)
         {
             case "show": context.VisibleKey = context.ApiKey; break;
@@ -432,6 +416,7 @@ else
             case "refresh": await RefreshAsync(context); break;
             case "delete": await DeleteAsync(context); break;
         }
+        StateHasChanged();
     }
 
     private async Task CopyToClipboard(ApiKeyModel context)

--- a/Tharga.Team.Blazor/Features/Api/ApiKeyView.razor
+++ b/Tharga.Team.Blazor/Features/Api/ApiKeyView.razor
@@ -1,9 +1,7 @@
 @using Microsoft.Extensions.DependencyInjection
 @using Microsoft.Extensions.Options
 @using Microsoft.JSInterop
-@using Tharga.Team
 @using Tharga.Team.Blazor.Features.Team
-@using Microsoft.AspNetCore.Components.Authorization
 @inject ITeamStateService TeamStateService
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IOptions<ApiKeyOptions> ApiKeyOptionsAccessor
@@ -116,16 +114,47 @@ else
                     }
                 </Template>
             </RadzenDataGridColumn>
-            <RadzenDataGridColumn Width="@GetActionsColumnWidth()">
+            <RadzenDataGridColumn Width="170px" TextAlign="TextAlign.Right">
                 <Template>
-                    <RadzenButton Icon="visibility" Click="@(_ => context.VisibleKey = context.ApiKey)" Visible="@(!string.IsNullOrEmpty(context.ApiKey) && context.VisibleKey == _apiKeyMask)" />
-                    <RadzenButton Icon="visibility_off" Click="@(_ => context.VisibleKey = _apiKeyMask)" Visible="@(!string.IsNullOrEmpty(context.ApiKey) && context.VisibleKey != _apiKeyMask)" />
-                    <RadzenButton Icon="content_copy" Click="@(_ => CopyToClipboard(context))" Visible="@(!string.IsNullOrEmpty(context.ApiKey))" />
-                    <RadzenButton Icon="manage_search" Click="@(_ => OpenAuditLogAsync(context))" Visible="@ShowAuditLogButton" title="View audit log for this key" />
-                    <RadzenButton Icon="tune" Click="@(_ => OpenEditAsync(context))" Visible="@((ShowScopeOverrides && _scopeRegistry != null) || (ShowRoles && _tenantRoleRegistry != null))" title="Edit roles &amp; scopes" />
-                    <RadzenButton Icon="lock" Click="@(_ => LockKeyAsync(context))" Visible="@(!string.IsNullOrEmpty(context.ApiKey))" />
-                    <RadzenButton Icon="refresh" Click="@(_ => RefreshAsync(context))" />
-                    <RadzenButton Icon="delete" ButtonStyle="ButtonStyle.Danger" Variant="Variant.Flat" Click="@(_ => DeleteAsync(context))" Visible="@(_options.AdvancedMode)" />
+                    @{
+                        var hasValue = !string.IsNullOrEmpty(context.ApiKey);
+                        var showEdit = (ShowScopeOverrides && _scopeRegistry != null) || (ShowRoles && _tenantRoleRegistry != null);
+                    }
+                    <RadzenSplitButton Text="@(hasValue ? "Copy" : "")"
+                                       Icon="@(hasValue ? "content_copy" : "more_vert")"
+                                       Click="@(args => OnRowActionAsync(context, args))">
+                        <ChildContent>
+                            @* @if (hasValue)
+                            {
+                                <RadzenSplitButtonItem Text="Copy" Icon="content_copy" Value="copy" />
+                            } *@
+                            @if (hasValue && context.VisibleKey == _apiKeyMask)
+                            {
+                                <RadzenSplitButtonItem Text="Show value" Icon="visibility" Value="show" />
+                            }
+                            @if (hasValue && context.VisibleKey != _apiKeyMask)
+                            {
+                                <RadzenSplitButtonItem Text="Hide value" Icon="visibility_off" Value="hide" />
+                            }
+                            @if (ShowAuditLogButton)
+                            {
+                                <RadzenSplitButtonItem Text="Audit log" Icon="manage_search" Value="audit" />
+                            }
+                            @if (showEdit)
+                            {
+                                <RadzenSplitButtonItem Text="Edit roles & scopes" Icon="tune" Value="edit" />
+                            }
+                            @if (hasValue)
+                            {
+                                <RadzenSplitButtonItem Text="Lock" Icon="lock" Value="lock" />
+                            }
+                            <RadzenSplitButtonItem Text="Refresh" Icon="refresh" Value="refresh" />
+                            @if (_options.AdvancedMode)
+                            {
+                                <RadzenSplitButtonItem Text="Delete" Icon="delete" Value="delete" />
+                            }
+                        </ChildContent>
+                    </RadzenSplitButton>
                 </Template>
             </RadzenDataGridColumn>
         </Columns>
@@ -388,6 +417,23 @@ else
         return !string.IsNullOrEmpty(context.VisibleKey) && context.VisibleKey != _apiKeyMask;
     }
 
+    private async Task OnRowActionAsync(ApiKeyModel context, RadzenSplitButtonItem item)
+    {
+        // item is null when the primary button is clicked: copy when there's a value, otherwise no-op.
+        var action = item?.Value ?? (string.IsNullOrEmpty(context.ApiKey) ? null : "copy");
+        switch (action)
+        {
+            case "show": context.VisibleKey = context.ApiKey; break;
+            case "hide": context.VisibleKey = _apiKeyMask; break;
+            case "copy": await CopyToClipboard(context); break;
+            case "audit": await OpenAuditLogAsync(context); break;
+            case "edit": await OpenEditAsync(context); break;
+            case "lock": await LockKeyAsync(context); break;
+            case "refresh": await RefreshAsync(context); break;
+            case "delete": await DeleteAsync(context); break;
+        }
+    }
+
     private async Task CopyToClipboard(ApiKeyModel context)
     {
         var keyToCopy = IsKeyVisible(context) ? context.VisibleKey : context.ApiKey;
@@ -426,10 +472,10 @@ else
 
     private async Task OpenAuditLogAsync(ApiKeyModel context)
     {
-        var pinned = new Tharga.Team.Blazor.Features.Audit.AuditPinnedFilter
+        var pinned = new Audit.AuditPinnedFilter
         {
             CallerKeyId = context.Key,
-            CallerType = Tharga.Team.Service.Audit.AuditCallerType.ApiKey,
+            CallerType = Service.Audit.AuditCallerType.ApiKey,
         };
 
         await DialogService.OpenAsync($"Audit log — {context.Name}", _ =>
@@ -490,14 +536,4 @@ else
         }
     }
 
-    private string GetActionsColumnWidth()
-    {
-        // Base 180px (matches the original simple-mode width), +40 for delete in advanced mode,
-        // +40 when the audit log button is shown, +40 when the edit (roles/scopes) button is shown.
-        var width = 180;
-        if (_options?.AdvancedMode == true) width += 40;
-        if (ShowAuditLogButton) width += 40;
-        if ((ShowScopeOverrides && _scopeRegistry != null) || (ShowRoles && _tenantRoleRegistry != null)) width += 40;
-        return $"{width}px";
-    }
 }

--- a/Tharga.Team.Blazor/Features/Api/ApiKeyView.razor
+++ b/Tharga.Team.Blazor/Features/Api/ApiKeyView.razor
@@ -210,7 +210,7 @@ else
     /// <summary>When true (and an <see cref="ITenantRoleRegistry"/> is registered), allows assigning tenant roles to keys (create card + edit dialog). Default false.</summary>
     [Parameter] public bool ShowRoles { get; set; }
 
-    /// <summary>Shows the "Last used" column (tooltip lists Created + Expiry dates; a warning icon appears within 60 days of expiry). Default true.</summary>
+    /// <summary>Shows the "Last used" column (tooltip lists Created + Expiry + Created by; a warning icon appears within 60 days of expiry). Default true.</summary>
     [Parameter] public bool ShowLastUsed { get; set; } = true;
 
     /// <summary>
@@ -294,6 +294,7 @@ else
                     ScopeOverrides = x.ScopeOverrides,
                     ExpiryDate = x.ExpiryDate,
                     CreatedAt = x.CreatedAt,
+                    CreatedBy = x.CreatedBy,
                     LastUsedAt = x.LastUsedAt,
                     Tags = x.Tags ?? Array.Empty<Tag>(),
                 };
@@ -373,7 +374,8 @@ else
     {
         var created = context.CreatedAt.HasValue ? context.CreatedAt.Value.ToString("yyyy-MM-dd") : "—";
         var expires = context.ExpiryDate.HasValue ? context.ExpiryDate.Value.ToString("yyyy-MM-dd") : "No expiry";
-        return $"Created: {created}\nExpires: {expires}";
+        var by = string.IsNullOrWhiteSpace(context.CreatedBy) ? "System" : context.CreatedBy;
+        return $"Created: {created}\nExpires: {expires}\nCreated by: {by}";
     }
 
     private static bool IsExpiringSoon(ApiKeyModel context)

--- a/Tharga.Team.Blazor/Features/Api/SystemApiKeyView.razor
+++ b/Tharga.Team.Blazor/Features/Api/SystemApiKeyView.razor
@@ -6,6 +6,7 @@
 @inject IJSRuntime Js
 @inject DialogService DialogService
 @inject NotificationService NotificationService
+@inject ContextMenuService ContextMenuService
 
 <AuthorizeView Roles="@Roles.Developer" Context="authState">
     <Authorized>
@@ -51,15 +52,10 @@
                             }
                         </Template>
                     </RadzenDataGridColumn>
-                    <RadzenDataGridColumn Width="@(ShowAuditLogButton ? "260px" : "220px")">
+                    <RadzenDataGridColumn Width="56px" TextAlign="TextAlign.Right">
                         <Template>
-                            <RadzenButton Icon="visibility" Click="@(_ => context.VisibleKey = context.ApiKey)" Visible="@(!string.IsNullOrEmpty(context.ApiKey) && context.VisibleKey == _apiKeyMask)" />
-                            <RadzenButton Icon="visibility_off" Click="@(_ => context.VisibleKey = _apiKeyMask)" Visible="@(!string.IsNullOrEmpty(context.ApiKey) && context.VisibleKey != _apiKeyMask)" />
-                            <RadzenButton Icon="content_copy" Click="@(_ => CopyToClipboard(context))" Visible="@(!string.IsNullOrEmpty(context.ApiKey))" />
-                            <RadzenButton Icon="manage_search" Click="@(_ => OpenAuditLogAsync(context))" Visible="@ShowAuditLogButton" title="View audit log for this key" />
-                            <RadzenButton Icon="lock" Click="@(_ => LockKeyAsync(context))" Visible="@(!string.IsNullOrEmpty(context.ApiKey))" />
-                            <RadzenButton Icon="refresh" Click="@(_ => RefreshAsync(context))" />
-                            <RadzenButton Icon="delete" ButtonStyle="ButtonStyle.Danger" Variant="Variant.Flat" Click="@(_ => DeleteAsync(context))" />
+                            <RadzenButton Icon="more_vert" Variant="Variant.Flat" ButtonStyle="ButtonStyle.Base"
+                                          Click="@(args => OpenRowMenu(args, context))" title="Actions" />
                         </Template>
                     </RadzenDataGridColumn>
                 </Columns>
@@ -219,6 +215,41 @@
         if (key == null || string.IsNullOrEmpty(key.ApiKey)) return;
         var model = _keys?.FirstOrDefault(k => k.Key == key.Key);
         if (model != null) model.VisibleKey = key.ApiKey;
+        StateHasChanged();
+    }
+
+    private void OpenRowMenu(MouseEventArgs args, SystemApiKeyModel context)
+    {
+        var hasValue = !string.IsNullOrEmpty(context.ApiKey);
+
+        var items = new List<ContextMenuItem>();
+        if (hasValue) items.Add(new ContextMenuItem { Text = "Copy", Icon = "content_copy", Value = "copy" });
+        if (hasValue && context.VisibleKey == _apiKeyMask) items.Add(new ContextMenuItem { Text = "Show value", Icon = "visibility", Value = "show" });
+        if (hasValue && context.VisibleKey != _apiKeyMask) items.Add(new ContextMenuItem { Text = "Hide value", Icon = "visibility_off", Value = "hide" });
+        if (ShowAuditLogButton) items.Add(new ContextMenuItem { Text = "Audit log", Icon = "manage_search", Value = "audit" });
+        if (hasValue) items.Add(new ContextMenuItem { Text = "Lock", Icon = "lock", Value = "lock" });
+        items.Add(new ContextMenuItem { Text = "Refresh", Icon = "refresh", Value = "refresh" });
+        items.Add(new ContextMenuItem { Text = "Delete", Icon = "delete", Value = "delete" });
+
+        ContextMenuService.Open(args, items, async e =>
+        {
+            ContextMenuService.Close();
+            await OnRowActionAsync(context, e.Value as string);
+        });
+    }
+
+    private async Task OnRowActionAsync(SystemApiKeyModel context, string action)
+    {
+        switch (action)
+        {
+            case "show": context.VisibleKey = context.ApiKey; break;
+            case "hide": context.VisibleKey = _apiKeyMask; break;
+            case "copy": await CopyToClipboard(context); break;
+            case "audit": await OpenAuditLogAsync(context); break;
+            case "lock": await LockKeyAsync(context); break;
+            case "refresh": await RefreshAsync(context); break;
+            case "delete": await DeleteAsync(context); break;
+        }
         StateHasChanged();
     }
 

--- a/Tharga.Team.Blazor/Features/Api/SystemApiKeyView.razor
+++ b/Tharga.Team.Blazor/Features/Api/SystemApiKeyView.razor
@@ -129,7 +129,7 @@
     {
         var created = context.CreatedAt.HasValue ? context.CreatedAt.Value.ToString("yyyy-MM-dd") : "—";
         var expires = context.ExpiryDate.HasValue ? context.ExpiryDate.Value.ToString("yyyy-MM-dd") : "No expiry";
-        var by = string.IsNullOrWhiteSpace(context.CreatedBy) ? "—" : context.CreatedBy;
+        var by = string.IsNullOrWhiteSpace(context.CreatedBy) ? "System" : context.CreatedBy;
         return $"Created: {created}\nExpires: {expires}\nCreated by: {by}";
     }
 

--- a/Tharga.Team.Service.Tests/ApiKeyAdministrationServiceTests.cs
+++ b/Tharga.Team.Service.Tests/ApiKeyAdministrationServiceTests.cs
@@ -342,6 +342,43 @@ public class ApiKeyAdministrationServiceTests
     }
 
     [Fact]
+    public async Task CreateKeyAsync_Persists_CreatedBy()
+    {
+        _apiKeyService.BuildApiKey(Arg.Any<string>(), Arg.Any<Func<string>>()).Returns("new-key");
+        _apiKeyService.Encrypt("new-key").Returns("new-hash");
+        _repository.AddAsync(Arg.Any<ApiKeyEntity>()).Returns(ci => Task.FromResult(ci.Arg<ApiKeyEntity>()));
+
+        await _sut.CreateKeyAsync("team-1", "My Key", AccessLevel.User, createdBy: "alice@example.com");
+
+        await _repository.Received(1).AddAsync(Arg.Is<ApiKeyEntity>(e => e.CreatedBy == "alice@example.com"));
+    }
+
+    [Fact]
+    public async Task CreateKeyAsync_Without_CreatedBy_LeavesFieldNull()
+    {
+        _apiKeyService.BuildApiKey(Arg.Any<string>(), Arg.Any<Func<string>>()).Returns("new-key");
+        _apiKeyService.Encrypt("new-key").Returns("new-hash");
+        _repository.AddAsync(Arg.Any<ApiKeyEntity>()).Returns(ci => Task.FromResult(ci.Arg<ApiKeyEntity>()));
+
+        await _sut.CreateKeyAsync("team-1", "My Key", AccessLevel.User);
+
+        await _repository.Received(1).AddAsync(Arg.Is<ApiKeyEntity>(e => e.CreatedBy == null));
+    }
+
+    [Fact]
+    public async Task RefreshKeyAsync_Preserves_CreatedBy()
+    {
+        var existing = CreateEntity("key-1", "old-hash", "team-1") with { CreatedBy = "alice@example.com" };
+        _repository.GetAsync("key-1").Returns(Task.FromResult(existing));
+        _apiKeyService.BuildApiKey(Arg.Any<string>(), Arg.Any<Func<string>>()).Returns("refreshed-key");
+        _apiKeyService.Encrypt("refreshed-key").Returns("refreshed-hash");
+
+        await _sut.RefreshKeyAsync("team-1", "key-1");
+
+        await _repository.Received(1).UpdateAsync("key-1", Arg.Is<ApiKeyEntity>(e => e.CreatedBy == "alice@example.com"));
+    }
+
+    [Fact]
     public async Task CreateKeyAsync_With_Custom_AccessLevel_Persists_Custom_And_Overrides()
     {
         // The headline #74 use case: a least-privilege machine key minted with Custom + a single

--- a/Tharga.Team.Service.Tests/ApiKeyManagementServiceTests.cs
+++ b/Tharga.Team.Service.Tests/ApiKeyManagementServiceTests.cs
@@ -1,3 +1,5 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
 using Tharga.Team;
 
 namespace Tharga.Team.Service.Tests;
@@ -13,6 +15,22 @@ public class ApiKeyManagementServiceTests
 
         await sut.CreateKeyAsync("team-1", "My Key", AccessLevel.Custom, tags: tags);
 
-        await inner.Received(1).CreateKeyAsync("team-1", "My Key", AccessLevel.Custom, null, null, null, tags);
+        await inner.Received(1).CreateKeyAsync("team-1", "My Key", AccessLevel.Custom, null, null, null, tags, null);
+    }
+
+    [Fact]
+    public async Task CreateKeyAsync_Forwards_CurrentUser_As_CreatedBy()
+    {
+        var inner = Substitute.For<IApiKeyAdministrationService>();
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, "alice@example.com") })),
+        });
+        var sut = new ApiKeyManagementService(inner, accessor);
+
+        await sut.CreateKeyAsync("team-1", "My Key", AccessLevel.User);
+
+        await inner.Received(1).CreateKeyAsync("team-1", "My Key", AccessLevel.User, null, null, null, null, "alice@example.com");
     }
 }

--- a/Tharga.Team.Service/ApiKeyAdministrationService.cs
+++ b/Tharga.Team.Service/ApiKeyAdministrationService.cs
@@ -96,7 +96,7 @@ public class ApiKeyAdministrationService : IApiKeyAdministrationService
         {
             var name = IntegerExtensions.GetNameForNumber(i + 1);
             var expiryDate = GetDefaultExpiryDate();
-            var entity = BuildKey(teamKey, name, [], AccessLevel.User, null, null, expiryDate);
+            var entity = BuildKey(teamKey, name, [], AccessLevel.User, null, null, expiryDate, createdBy: null);
             var created = await _repository.AddAsync(entity);
 
             if (_options.AutoLockKeys)
@@ -110,7 +110,7 @@ public class ApiKeyAdministrationService : IApiKeyAdministrationService
     }
 
     /// <inheritdoc />
-    public async Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null, IReadOnlyList<Tag> tags = null)
+    public async Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null, IReadOnlyList<Tag> tags = null, string createdBy = null)
     {
         expiryDate ??= GetDefaultExpiryDate();
 
@@ -121,7 +121,7 @@ public class ApiKeyAdministrationService : IApiKeyAdministrationService
                 throw new InvalidOperationException($"Expiry date cannot exceed {_options.MaxExpiryDays} days from now.");
         }
 
-        var entity = BuildKey(teamKey, name, tags, accessLevel, roles, scopeOverrides, expiryDate);
+        var entity = BuildKey(teamKey, name, tags, accessLevel, roles, scopeOverrides, expiryDate, createdBy);
         var created = await _repository.AddAsync(entity);
 
         if (_options.AutoLockKeys)
@@ -135,7 +135,7 @@ public class ApiKeyAdministrationService : IApiKeyAdministrationService
     {
         var item = await _repository.GetAsync(key);
         VerifyTeamOwnership(item, teamKey);
-        var refreshed = BuildKey(teamKey, item.Name, item.Tags, item.AccessLevel ?? AccessLevel.Administrator, item.Roles, item.ScopeOverrides, item.ExpiryDate);
+        var refreshed = BuildKey(teamKey, item.Name, item.Tags, item.AccessLevel ?? AccessLevel.Administrator, item.Roles, item.ScopeOverrides, item.ExpiryDate, item.CreatedBy);
         await _repository.UpdateAsync(key, refreshed);
 
         if (_options.AutoLockKeys)
@@ -263,7 +263,7 @@ public class ApiKeyAdministrationService : IApiKeyAdministrationService
             : null;
     }
 
-    private ApiKeyEntity BuildKey(string teamKey, string name, IReadOnlyList<Tag> tags, AccessLevel accessLevel, string[] roles, string[] scopeOverrides, DateTime? expiryDate)
+    private ApiKeyEntity BuildKey(string teamKey, string name, IReadOnlyList<Tag> tags, AccessLevel accessLevel, string[] roles, string[] scopeOverrides, DateTime? expiryDate, string createdBy)
     {
         var apiKey = _apiKeyService.BuildApiKey(teamKey, () => StringExtension.GetRandomString(24, 32));
         var encryptedApiKey = _apiKeyService.Encrypt(apiKey);
@@ -282,6 +282,7 @@ public class ApiKeyAdministrationService : IApiKeyAdministrationService
             ScopeOverrides = scopeOverrides,
             ExpiryDate = expiryDate,
             CreatedAt = DateTime.UtcNow,
+            CreatedBy = createdBy,
         };
     }
 

--- a/Tharga.Team.Service/ApiKeyManagementService.cs
+++ b/Tharga.Team.Service/ApiKeyManagementService.cs
@@ -20,7 +20,7 @@ public class ApiKeyManagementService : IApiKeyManagementService
     }
 
     public IAsyncEnumerable<IApiKey> GetKeysAsync(string teamKey) => _inner.GetKeysAsync(teamKey);
-    public Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null, IReadOnlyList<Tag> tags = null) => _inner.CreateKeyAsync(teamKey, name, accessLevel, roles, scopeOverrides, expiryDate, tags);
+    public Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null, IReadOnlyList<Tag> tags = null) => _inner.CreateKeyAsync(teamKey, name, accessLevel, roles, scopeOverrides, expiryDate, tags, GetCurrentUserIdentity());
     public Task<IApiKey> RefreshKeyAsync(string teamKey, string key) => _inner.RefreshKeyAsync(teamKey, key);
     public Task LockKeyAsync(string teamKey, string key) => _inner.LockKeyAsync(teamKey, key);
     public Task DeleteKeyAsync(string teamKey, string key) => _inner.DeleteKeyAsync(teamKey, key);

--- a/Tharga.Team.Service/Audit/AuditingApiKeyServiceDecorator.cs
+++ b/Tharga.Team.Service/Audit/AuditingApiKeyServiceDecorator.cs
@@ -30,12 +30,12 @@ public class AuditingApiKeyServiceDecorator : IApiKeyAdministrationService
 
     // Mutation operations — log audit entries
 
-    public async Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null, IReadOnlyList<Tag> tags = null)
+    public async Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null, IReadOnlyList<Tag> tags = null, string createdBy = null)
     {
         var sw = Stopwatch.StartNew();
         try
         {
-            var result = await _inner.CreateKeyAsync(teamKey, name, accessLevel, roles, scopeOverrides, expiryDate, tags);
+            var result = await _inner.CreateKeyAsync(teamKey, name, accessLevel, roles, scopeOverrides, expiryDate, tags, createdBy);
             sw.Stop();
             Log("create", nameof(CreateKeyAsync), sw.ElapsedMilliseconds, true, teamKey: teamKey);
             return result;

--- a/Tharga.Team/IApiKeyAdministrationService.cs
+++ b/Tharga.Team/IApiKeyAdministrationService.cs
@@ -11,8 +11,8 @@ public interface IApiKeyAdministrationService
     /// <summary>Returns all API keys for the specified team, creating default keys if fewer than AutoKeyCount exist.</summary>
     IAsyncEnumerable<IApiKey> GetKeysAsync(string teamKey);
 
-    /// <summary>Creates a new API key with the specified settings (advanced mode). <paramref name="tags"/> are system-set key-value tags, settable only here (not from the UI) and immutable thereafter.</summary>
-    Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null, IReadOnlyList<Tag> tags = null);
+    /// <summary>Creates a new API key with the specified settings (advanced mode). <paramref name="tags"/> are system-set key-value tags, settable only here (not from the UI) and immutable thereafter. <paramref name="createdBy"/> records who created the key; <c>null</c> for keys created without a user context (e.g. auto-generated), surfaced as "System" in the UI.</summary>
+    Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null, IReadOnlyList<Tag> tags = null, string createdBy = null);
 
     /// <summary>Generates a new API key value for an existing key entry. Returns the entity with the raw key visible once.</summary>
     Task<IApiKey> RefreshKeyAsync(string teamKey, string key);


### PR DESCRIPTION
Improvements to the API-key views, on top of 3.0.0.

## Features
- **Record `CreatedBy` on team API keys** — stamped at creation (resolved from the current user via `HttpContext`), preserved on refresh; auto-generated keys have no user and surface as **"System"** in the UI. `IApiKeyAdministrationService.CreateKeyAsync` gains an optional `createdBy`; the public management signature is unchanged. The "Last used" tooltip now shows "Created by".
- **"System" fallback for system keys** with no creator (`SystemApiKeyView`, was an em dash).

## UI refactor
- **Row actions consolidated into a context menu.** Both `ApiKeyView` and `SystemApiKeyView` replace their row of inline icon buttons with a single `more_vert` button opening a Radzen `ContextMenu` (icon-bearing items: copy, show/hide, audit, edit roles & scopes [team keys only], lock, refresh, delete). Opens at the click point and grows leftward to stay on screen; actions column narrowed to 56px.
  - Note: **Delete** is now a confirm-gated menu item rather than a red button (`ContextMenuItem` has no per-item style).
  - Consumers need `<RadzenComponents />` + `AddRadzenComponents()` (already required for the dialogs/notifications these views use).

## Sample
- `ApiKeysPage`: one-click **"Create tagged key"** button (mints a team key with a `Type=demo` tag, shown as a chip).
- Enabled `o.Blazor.Consent.ShowToggle` to demo per-team consent.

## Tests
Service 200✓, Blazor 101✓; full solution builds clean. 4 new tests cover `CreatedBy` (persisted / null / preserved on refresh / resolved from HttpContext).

_History note: `5eff871` is a superseded split-button version, kept then replaced by the context menu in `a967e58`._