### PR TITLE
Configurable API-key secret length (closes #82)

### DIFF
--- a/Tharga.Team.Blazor.Tests/AddThargaPlatformTests.cs
+++ b/Tharga.Team.Blazor.Tests/AddThargaPlatformTests.cs
@@ -160,6 +160,28 @@ public class AddThargaPlatformTests
     }
 
     [Fact]
+    public void ForwardsApiKeyOptions_To_ApiKeyOptions()
+    {
+        var builder = CreateBuilder();
+        builder.AddThargaPlatform(o =>
+        {
+            o.ApiKey.MinKeyLength = 40;
+            o.ApiKey.MaxKeyLength = 48;
+            o.ApiKey.MaxExpiryDays = 30;
+            o.ApiKey.LastUsedThrottle = TimeSpan.FromMinutes(5);
+            o.ApiKey.AutoLockKeys = true;
+        });
+        var provider = builder.Services.BuildServiceProvider();
+
+        var options = provider.GetRequiredService<IOptions<ApiKeyOptions>>().Value;
+        Assert.Equal(40, options.MinKeyLength);
+        Assert.Equal(48, options.MaxKeyLength);
+        Assert.Equal(30, options.MaxExpiryDays);
+        Assert.Equal(TimeSpan.FromMinutes(5), options.LastUsedThrottle);
+        Assert.True(options.AutoLockKeys);
+    }
+
+    [Fact]
     public void SkipsApiKeyAuth_WhenNull()
     {
         var builder = CreateBuilder();

--- a/Tharga.Team.Blazor/Framework/ThargaPlatformRegistration.cs
+++ b/Tharga.Team.Blazor/Framework/ThargaPlatformRegistration.cs
@@ -38,10 +38,14 @@ public static class ThargaPlatformRegistration
                 .AddAuthentication()
                 .AddThargaApiKeyAuthentication(o =>
                 {
+                    // Keep in sync with ApiKeyOptions — forward every setting the consumer set on o.ApiKey.
                     o.AdvancedMode = options.ApiKey.AdvancedMode;
                     o.AutoKeyCount = options.ApiKey.AutoKeyCount;
                     o.AutoLockKeys = options.ApiKey.AutoLockKeys;
                     o.MaxExpiryDays = options.ApiKey.MaxExpiryDays;
+                    o.LastUsedThrottle = options.ApiKey.LastUsedThrottle;
+                    o.MinKeyLength = options.ApiKey.MinKeyLength;
+                    o.MaxKeyLength = options.ApiKey.MaxKeyLength;
                 });
 
             builder.Services.AddThargaApiKeys();

--- a/Tharga.Team.Service.Tests/ApiKeyAdministrationServiceTests.cs
+++ b/Tharga.Team.Service.Tests/ApiKeyAdministrationServiceTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Options;
 using Tharga.Toolkit.Password;
 
 namespace Tharga.Team.Service.Tests;
@@ -376,6 +377,107 @@ public class ApiKeyAdministrationServiceTests
         await _sut.RefreshKeyAsync("team-1", "key-1");
 
         await _repository.Received(1).UpdateAsync("key-1", Arg.Is<ApiKeyEntity>(e => e.CreatedBy == "alice@example.com"));
+    }
+
+    [Fact]
+    public async Task CreateKeyAsync_Uses_Default_Fixed_Length_Of_32()
+    {
+        Func<string> generator = null;
+        _apiKeyService.BuildApiKey(Arg.Any<string>(), Arg.Do<Func<string>>(f => generator = f)).Returns("new-key");
+        _apiKeyService.Encrypt("new-key").Returns("new-hash");
+        _repository.AddAsync(Arg.Any<ApiKeyEntity>()).Returns(ci => Task.FromResult(ci.Arg<ApiKeyEntity>()));
+
+        await _sut.CreateKeyAsync("team-1", "My Key", AccessLevel.User);
+
+        // MaxKeyLength is null by default → fixed length at MinKeyLength (32).
+        Assert.NotNull(generator);
+        Assert.Equal(32, generator().Length);
+    }
+
+    [Fact]
+    public async Task CreateKeyAsync_Null_Max_Uses_Min_As_Fixed_Length()
+    {
+        var sut = new ApiKeyAdministrationService(_repository, _apiKeyService, Options.Create(new ApiKeyOptions { MinKeyLength = 48 }));
+        Func<string> generator = null;
+        _apiKeyService.BuildApiKey(Arg.Any<string>(), Arg.Do<Func<string>>(f => generator = f)).Returns("new-key");
+        _apiKeyService.Encrypt("new-key").Returns("new-hash");
+        _repository.AddAsync(Arg.Any<ApiKeyEntity>()).Returns(ci => Task.FromResult(ci.Arg<ApiKeyEntity>()));
+
+        await sut.CreateKeyAsync("team-1", "My Key", AccessLevel.User);
+
+        Assert.NotNull(generator);
+        Assert.Equal(48, generator().Length);
+    }
+
+    [Fact]
+    public async Task CreateKeyAsync_With_Max_Uses_Random_Range()
+    {
+        var sut = new ApiKeyAdministrationService(_repository, _apiKeyService, Options.Create(new ApiKeyOptions { MinKeyLength = 40, MaxKeyLength = 64 }));
+        Func<string> generator = null;
+        _apiKeyService.BuildApiKey(Arg.Any<string>(), Arg.Do<Func<string>>(f => generator = f)).Returns("new-key");
+        _apiKeyService.Encrypt("new-key").Returns("new-hash");
+        _repository.AddAsync(Arg.Any<ApiKeyEntity>()).Returns(ci => Task.FromResult(ci.Arg<ApiKeyEntity>()));
+
+        await sut.CreateKeyAsync("team-1", "My Key", AccessLevel.User);
+
+        Assert.NotNull(generator);
+        Assert.InRange(generator().Length, 40, 64);
+    }
+
+    [Fact]
+    public async Task CreateSystemKeyAsync_Uses_Configured_Length()
+    {
+        var sut = new ApiKeyAdministrationService(_repository, _apiKeyService, Options.Create(new ApiKeyOptions { MinKeyLength = 40 }));
+        Func<string> generator = null;
+        _apiKeyService.BuildApiKey(Arg.Any<string>(), Arg.Do<Func<string>>(f => generator = f)).Returns("new-key");
+        _apiKeyService.Encrypt("new-key").Returns("new-hash");
+        _repository.AddAsync(Arg.Any<ApiKeyEntity>()).Returns(ci => Task.FromResult(ci.Arg<ApiKeyEntity>()));
+
+        await sut.CreateSystemKeyAsync("Sys Key", new[] { "sys:read" });
+
+        Assert.NotNull(generator);
+        Assert.Equal(40, generator().Length);
+    }
+
+    [Fact]
+    public async Task CreateKeyAsync_Throws_When_Max_Below_Min()
+    {
+        var sut = new ApiKeyAdministrationService(_repository, _apiKeyService, Options.Create(new ApiKeyOptions { MinKeyLength = 40, MaxKeyLength = 32 }));
+        Func<string> generator = null;
+        _apiKeyService.BuildApiKey(Arg.Any<string>(), Arg.Do<Func<string>>(f => generator = f)).Returns("new-key");
+        _apiKeyService.Encrypt("new-key").Returns("new-hash");
+        _repository.AddAsync(Arg.Any<ApiKeyEntity>()).Returns(ci => Task.FromResult(ci.Arg<ApiKeyEntity>()));
+
+        await sut.CreateKeyAsync("team-1", "My Key", AccessLevel.User);
+
+        // Max 32 < Min 40 — the generator throws when invoked.
+        Assert.NotNull(generator);
+        Assert.Throws<InvalidOperationException>(() => generator());
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(23)]
+    public void MinKeyLength_Below_Floor_Throws(int value)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ApiKeyOptions { MinKeyLength = value });
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(23)]
+    public void MaxKeyLength_Below_Floor_Throws(int value)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ApiKeyOptions { MaxKeyLength = value });
+    }
+
+    [Fact]
+    public void KeyLength_Defaults_And_Floor()
+    {
+        var options = new ApiKeyOptions();
+        Assert.Equal(32, options.MinKeyLength);
+        Assert.Null(options.MaxKeyLength);
+        Assert.Equal(24, ApiKeyOptions.KeyLengthFloor);
     }
 
     [Fact]

--- a/Tharga.Team.Service/ApiKeyAdministrationService.cs
+++ b/Tharga.Team.Service/ApiKeyAdministrationService.cs
@@ -263,9 +263,18 @@ public class ApiKeyAdministrationService : IApiKeyAdministrationService
             : null;
     }
 
+    private string GenerateSecret()
+    {
+        var min = _options.MinKeyLength;
+        var max = _options.MaxKeyLength ?? min; // null = fixed length at MinKeyLength
+        if (max < min)
+            throw new InvalidOperationException($"ApiKeyOptions.MaxKeyLength ({max}) must be greater than or equal to MinKeyLength ({min}).");
+        return StringExtension.GetRandomString(min, max);
+    }
+
     private ApiKeyEntity BuildKey(string teamKey, string name, IReadOnlyList<Tag> tags, AccessLevel accessLevel, string[] roles, string[] scopeOverrides, DateTime? expiryDate, string createdBy)
     {
-        var apiKey = _apiKeyService.BuildApiKey(teamKey, () => StringExtension.GetRandomString(24, 32));
+        var apiKey = _apiKeyService.BuildApiKey(teamKey, GenerateSecret);
         var encryptedApiKey = _apiKeyService.Encrypt(apiKey);
         return new ApiKeyEntity
         {
@@ -288,7 +297,7 @@ public class ApiKeyAdministrationService : IApiKeyAdministrationService
 
     private ApiKeyEntity BuildSystemKey(string name, string[] scopes, DateTime? expiryDate, string createdBy)
     {
-        var apiKey = _apiKeyService.BuildApiKey("system", () => StringExtension.GetRandomString(24, 32));
+        var apiKey = _apiKeyService.BuildApiKey("system", GenerateSecret);
         var encryptedApiKey = _apiKeyService.Encrypt(apiKey);
         return new ApiKeyEntity
         {

--- a/Tharga.Team/ApiKeyOptions.cs
+++ b/Tharga.Team/ApiKeyOptions.cs
@@ -36,4 +36,61 @@ public class ApiKeyOptions
     /// stamp on every successful authentication. Default: 1 minute.
     /// </summary>
     public TimeSpan LastUsedThrottle { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Absolute floor for both <see cref="MinKeyLength"/> and <see cref="MaxKeyLength"/>. 24 alphanumeric
+    /// characters is ≈143 bits of entropy (well above 128-bit) and matches the historical minimum, so the
+    /// secret can never be configured weaker than keys minted before these options existed.
+    /// </summary>
+    public const int KeyLengthFloor = 24;
+
+    private int _minKeyLength = 32;
+    private int? _maxKeyLength;
+
+    /// <summary>
+    /// Number of random alphanumeric characters in the secret portion of a generated API key (the part
+    /// after the team/system prefix). When <see cref="MaxKeyLength"/> is null this is the exact, fixed
+    /// length; when it is set, this is the lower bound of a random range. Applies to every
+    /// <c>CreateKeyAsync</c> — team and system keys — on both create and recycle/regenerate. Default: 32
+    /// (≈190-bit). Must be ≥ <see cref="KeyLengthFloor"/> so it cannot be accidentally weakened; a smaller
+    /// value throws <see cref="ArgumentOutOfRangeException"/>.
+    /// </summary>
+    /// <remarks>
+    /// Secret entropy with the base62 alphabet (~5.95 bits per character):
+    /// <list type="table">
+    /// <item><term>22</term><description>≈128-bit</description></item>
+    /// <item><term>32</term><description>≈190-bit (default)</description></item>
+    /// <item><term>43</term><description>≈256-bit</description></item>
+    /// <item><term>65</term><description>≈384-bit</description></item>
+    /// <item><term>86</term><description>≈512-bit</description></item>
+    /// </list>
+    /// </remarks>
+    public int MinKeyLength
+    {
+        get => _minKeyLength;
+        set
+        {
+            if (value < KeyLengthFloor)
+                throw new ArgumentOutOfRangeException(nameof(value), value, $"{nameof(MinKeyLength)} must be at least {KeyLengthFloor}.");
+            _minKeyLength = value;
+        }
+    }
+
+    /// <summary>
+    /// Optional upper bound for the random secret length. When null (the default), every key uses a fixed
+    /// length of <see cref="MinKeyLength"/>; when set, each key's length is chosen at random in
+    /// [<see cref="MinKeyLength"/>, <see cref="MaxKeyLength"/>] via a cryptographic RNG. Must be ≥
+    /// <see cref="KeyLengthFloor"/>; the ≥ <see cref="MinKeyLength"/> relationship is enforced when a key
+    /// is generated.
+    /// </summary>
+    public int? MaxKeyLength
+    {
+        get => _maxKeyLength;
+        set
+        {
+            if (value.HasValue && value.Value < KeyLengthFloor)
+                throw new ArgumentOutOfRangeException(nameof(value), value, $"{nameof(MaxKeyLength)} must be at least {KeyLengthFloor}.");
+            _maxKeyLength = value;
+        }
+    }
 }

--- a/docs/articles/implementation-guide.md
+++ b/docs/articles/implementation-guide.md
@@ -621,8 +621,10 @@ builder.Services.AddAuthentication()
     o.AdvancedMode = false;                // default: false — simple mode auto-generates keys
     o.AutoKeyCount = 2;                    // default: 2 — number of auto-generated keys in simple mode
     o.AutoLockKeys = false;               // default: false — auto-lock keys after creation
-    o.MaxExpiryDays = 365;                // default: null — maximum key expiry in days
+    o.MaxExpiryDays = 365;                // default: 365 — maximum key expiry in days (null = no cap)
     o.LastUsedThrottle = TimeSpan.FromMinutes(1); // default: 1 min — min interval between "last used" timestamp writes per key (TimeSpan.Zero = stamp every request)
+    o.MinKeyLength = 32;            // default: 32 — alphanumeric chars in the key secret; fixed length unless MaxKeyLength is set (floor 24 ≈143-bit; team + system keys)
+    o.MaxKeyLength = null;          // default: null — when set, the length is random in [MinKeyLength, MaxKeyLength] per key instead of fixed
 });
 ```
 


### PR DESCRIPTION
Closes #82.

## What
Add **`ApiKeyOptions.MinKeyLength` / `MaxKeyLength`** to control the random alphanumeric secret length of generated API keys (team **and** system keys, on both create and recycle).

- **`MinKeyLength`** (`int`, default **32**) — the fixed secret length unless a max is set.
- **`MaxKeyLength`** (`int?`, default **null**) — when set, each key's length is chosen at random in `[MinKeyLength, MaxKeyLength]` (matches the underlying `GetRandomString(min, max)`); when null, the length is fixed at `MinKeyLength`.
- **`KeyLengthFloor`** (const **24**, ≈143-bit) — both bounds are validated against it (`ArgumentOutOfRangeException` below it), so the secret can't be accidentally weakened. The `min <= max` relationship is checked when a key is generated.

## Behavior / back-compat
The secret was previously a hard-coded random **24–32** range. It's now a **fixed 32** by default — strictly ≥ the old maximum, so new keys are at least as strong and **existing keys are untouched** (verification doesn't depend on length).

Reference (base62 alphabet, ~5.95 bits/char): 32 → ~190-bit, 43 → ~256-bit, 86 → ~512-bit.

## Bonus fix
`AddThargaPlatform` copied `ApiKeyOptions` field-by-field into the inner API-key auth setup and **silently dropped `LastUsedThrottle`** (pre-existing) on top of the new length options. Now forwarded, with a test asserting `o.ApiKey.*` settings reach `IOptions<ApiKeyOptions>` so it can't drift again.

## Usage
```csharp
builder.AddThargaPlatform(o =>
{
    o.ApiKey.MinKeyLength = 43;   // ≈256-bit fixed-length secret
    // o.ApiKey.MaxKeyLength = 64; // opt into a random [Min, Max] range instead
});
```

## Tests
Service **210** ✓, Blazor **102** ✓, full solution builds clean. New tests: fixed default (32), null-max = fixed-at-min, random range, max<min guard, floor validation, and platform-forwarding.

Versioning: rides out as **3.0.2** with `MAJOR_MINOR=3.0` (additive).