### PR TITLE
API-key lifecycle hook to surface the private token (closes #83)

### DIFF
--- a/Tharga.Team.Service.Tests/ApiKeyLifecycleDecoratorTests.cs
+++ b/Tharga.Team.Service.Tests/ApiKeyLifecycleDecoratorTests.cs
@@ -1,0 +1,162 @@
+using Tharga.Team;
+
+namespace Tharga.Team.Service.Tests;
+
+public class ApiKeyLifecycleDecoratorTests
+{
+    private readonly IApiKeyAdministrationService _inner = Substitute.For<IApiKeyAdministrationService>();
+    private readonly RecordingHandler _handler = new();
+
+    private ApiKeyLifecycleDecorator CreateSut(params IApiKeyLifecycleHandler[] handlers)
+        => new(_inner, handlers.Length == 0 ? [_handler] : handlers);
+
+    private static IApiKey Key(string id = "key-1", string token = "raw-token", string team = "team-1",
+        string name = "My Key", IReadOnlyList<Tag> tags = null)
+    {
+        var k = Substitute.For<IApiKey>();
+        k.Key.Returns(id);
+        k.ApiKey.Returns(token);
+        k.TeamKey.Returns(team);
+        k.Name.Returns(name);
+        k.Tags.Returns(tags ?? [new Tag("Type", "demo")]);
+        return k;
+    }
+
+    [Fact]
+    public async Task CreateKeyAsync_Fires_Created_With_Token_And_Identity()
+    {
+        var key = Key();
+        _inner.CreateKeyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AccessLevel>(), Arg.Any<string[]>(),
+            Arg.Any<string[]>(), Arg.Any<DateTime?>(), Arg.Any<IReadOnlyList<Tag>>(), Arg.Any<string>())
+            .Returns(key);
+
+        await CreateSut().CreateKeyAsync("team-1", "My Key", AccessLevel.User);
+
+        var ctx = Assert.Single(_handler.Calls);
+        Assert.Equal(ApiKeyLifecycleReason.Created, ctx.Reason);
+        Assert.Equal("key-1", ctx.ApiKeyId);
+        Assert.Equal("raw-token", ctx.PrivateToken);
+        Assert.Equal("team-1", ctx.TeamKey);
+        Assert.False(ctx.IsSystemKey);
+        Assert.Equal("My Key", ctx.Name);
+        Assert.Equal("Type", Assert.Single(ctx.Tags).Key);
+    }
+
+    [Fact]
+    public async Task RefreshKeyAsync_Fires_Recycled_With_Token()
+    {
+        var key = Key(token: "new-token");
+        _inner.RefreshKeyAsync("team-1", "key-1").Returns(key);
+
+        await CreateSut().RefreshKeyAsync("team-1", "key-1");
+
+        var ctx = Assert.Single(_handler.Calls);
+        Assert.Equal(ApiKeyLifecycleReason.Recycled, ctx.Reason);
+        Assert.Equal("new-token", ctx.PrivateToken);
+    }
+
+    [Fact]
+    public async Task DeleteKeyAsync_Fires_Deleted_Without_Token()
+    {
+        await CreateSut().DeleteKeyAsync("team-1", "key-1");
+
+        var ctx = Assert.Single(_handler.Calls);
+        Assert.Equal(ApiKeyLifecycleReason.Deleted, ctx.Reason);
+        Assert.Equal("key-1", ctx.ApiKeyId);
+        Assert.Equal("team-1", ctx.TeamKey);
+        Assert.False(ctx.IsSystemKey);
+        Assert.Null(ctx.PrivateToken);
+    }
+
+    [Fact]
+    public async Task CreateSystemKeyAsync_Fires_Created_As_System()
+    {
+        var key = Key(team: null);
+        _inner.CreateSystemKeyAsync(Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<DateTime?>(), Arg.Any<string>())
+            .Returns(key);
+
+        await CreateSut().CreateSystemKeyAsync("Sys", ["sys:read"]);
+
+        var ctx = Assert.Single(_handler.Calls);
+        Assert.Equal(ApiKeyLifecycleReason.Created, ctx.Reason);
+        Assert.True(ctx.IsSystemKey);
+        Assert.Null(ctx.TeamKey);
+        Assert.Equal("raw-token", ctx.PrivateToken);
+    }
+
+    [Fact]
+    public async Task RefreshSystemKeyAsync_Fires_Recycled_As_System()
+    {
+        var key = Key(team: null);
+        _inner.RefreshSystemKeyAsync("key-1").Returns(key);
+
+        await CreateSut().RefreshSystemKeyAsync("key-1");
+
+        var ctx = Assert.Single(_handler.Calls);
+        Assert.Equal(ApiKeyLifecycleReason.Recycled, ctx.Reason);
+        Assert.True(ctx.IsSystemKey);
+    }
+
+    [Fact]
+    public async Task DeleteSystemKeyAsync_Fires_Deleted_As_System()
+    {
+        await CreateSut().DeleteSystemKeyAsync("key-1");
+
+        var ctx = Assert.Single(_handler.Calls);
+        Assert.Equal(ApiKeyLifecycleReason.Deleted, ctx.Reason);
+        Assert.True(ctx.IsSystemKey);
+        Assert.Null(ctx.TeamKey);
+        Assert.Null(ctx.PrivateToken);
+    }
+
+    [Fact]
+    public async Task Read_Lock_And_Set_Operations_Do_Not_Fire()
+    {
+        var sut = CreateSut();
+        await sut.GetByApiKeyAsync("raw");
+        await sut.LockKeyAsync("team-1", "key-1");
+        await sut.LockSystemKeyAsync("key-1");
+        await sut.SetScopeOverridesAsync("team-1", "key-1", ["doc:read"]);
+        await sut.SetRolesAsync("team-1", "key-1", ["Editor"]);
+
+        Assert.Empty(_handler.Calls);
+    }
+
+    [Fact]
+    public async Task Handler_Exception_Propagates_From_CreateKeyAsync()
+    {
+        var key = Key();
+        _inner.CreateKeyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AccessLevel>(), Arg.Any<string[]>(),
+            Arg.Any<string[]>(), Arg.Any<DateTime?>(), Arg.Any<IReadOnlyList<Tag>>(), Arg.Any<string>())
+            .Returns(key);
+        _handler.OnCall = _ => throw new InvalidOperationException("store failed");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => CreateSut().CreateKeyAsync("team-1", "My Key", AccessLevel.User));
+    }
+
+    [Fact]
+    public async Task All_Registered_Handlers_Are_Invoked()
+    {
+        var key = Key();
+        _inner.RefreshKeyAsync("team-1", "key-1").Returns(key);
+        var h2 = new RecordingHandler();
+
+        await CreateSut(_handler, h2).RefreshKeyAsync("team-1", "key-1");
+
+        Assert.Single(_handler.Calls);
+        Assert.Single(h2.Calls);
+    }
+
+    private sealed class RecordingHandler : IApiKeyLifecycleHandler
+    {
+        public readonly List<ApiKeyLifecycleContext> Calls = [];
+        public Func<ApiKeyLifecycleContext, Task> OnCall;
+
+        public Task OnApiKeyLifecycleAsync(ApiKeyLifecycleContext context)
+        {
+            Calls.Add(context);
+            return OnCall?.Invoke(context) ?? Task.CompletedTask;
+        }
+    }
+}

--- a/Tharga.Team.Service.Tests/ApiKeyLifecycleRegistrationTests.cs
+++ b/Tharga.Team.Service.Tests/ApiKeyLifecycleRegistrationTests.cs
@@ -1,0 +1,88 @@
+using Microsoft.Extensions.DependencyInjection;
+using Tharga.Team;
+
+namespace Tharga.Team.Service.Tests;
+
+public class ApiKeyLifecycleRegistrationTests
+{
+    private static IApiKey SampleKey()
+    {
+        var k = Substitute.For<IApiKey>();
+        k.Key.Returns("key-1");
+        k.ApiKey.Returns("raw-token");
+        k.TeamKey.Returns("team-1");
+        k.Name.Returns("My Key");
+        k.Tags.Returns([]);
+        return k;
+    }
+
+    private static IApiKeyAdministrationService InnerReturning(IApiKey key)
+    {
+        var inner = Substitute.For<IApiKeyAdministrationService>();
+        inner.CreateKeyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<AccessLevel>(), Arg.Any<string[]>(),
+            Arg.Any<string[]>(), Arg.Any<DateTime?>(), Arg.Any<IReadOnlyList<Tag>>(), Arg.Any<string>())
+            .Returns(key);
+        return inner;
+    }
+
+    [Fact]
+    public async Task Decorates_AdminService_And_Invokes_Handler()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<IApiKeyAdministrationService>(_ => InnerReturning(SampleKey()));
+        services.AddThargaApiKeyLifecycleHandler<RecordingA>();
+
+        var sp = services.BuildServiceProvider();
+        using var scope = sp.CreateScope();
+        var admin = scope.ServiceProvider.GetRequiredService<IApiKeyAdministrationService>();
+
+        Assert.IsType<ApiKeyLifecycleDecorator>(admin);
+
+        await admin.CreateKeyAsync("team-1", "My Key", AccessLevel.User);
+
+        var handler = (RecordingBase)scope.ServiceProvider.GetServices<IApiKeyLifecycleHandler>().Single();
+        var ctx = Assert.Single(handler.Calls);
+        Assert.Equal(ApiKeyLifecycleReason.Created, ctx.Reason);
+        Assert.Equal("raw-token", ctx.PrivateToken);
+    }
+
+    [Fact]
+    public async Task Multiple_Handlers_Decorate_Once_And_All_Fire()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<IApiKeyAdministrationService>(_ => InnerReturning(SampleKey()));
+        services.AddThargaApiKeyLifecycleHandler<RecordingA>();
+        services.AddThargaApiKeyLifecycleHandler<RecordingB>();
+
+        var sp = services.BuildServiceProvider();
+        using var scope = sp.CreateScope();
+        var admin = scope.ServiceProvider.GetRequiredService<IApiKeyAdministrationService>();
+
+        await admin.CreateKeyAsync("team-1", "My Key", AccessLevel.User);
+
+        var handlers = scope.ServiceProvider.GetServices<IApiKeyLifecycleHandler>().Cast<RecordingBase>().ToList();
+        Assert.Equal(2, handlers.Count);
+        // Single call each proves the decoration was applied once (a double-wrap would fire twice).
+        Assert.All(handlers, h => Assert.Single(h.Calls));
+    }
+
+    [Fact]
+    public void Throws_When_AdminService_Not_Registered()
+    {
+        var services = new ServiceCollection();
+        Assert.Throws<InvalidOperationException>(() => services.AddThargaApiKeyLifecycleHandler<RecordingA>());
+    }
+
+    private abstract class RecordingBase : IApiKeyLifecycleHandler
+    {
+        public readonly List<ApiKeyLifecycleContext> Calls = [];
+        public Task OnApiKeyLifecycleAsync(ApiKeyLifecycleContext context)
+        {
+            Calls.Add(context);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingA : RecordingBase;
+    private sealed class RecordingB : RecordingBase;
+}

--- a/Tharga.Team.Service/ApiKeyLifecycleDecorator.cs
+++ b/Tharga.Team.Service/ApiKeyLifecycleDecorator.cs
@@ -1,0 +1,116 @@
+using Tharga.Team;
+
+namespace Tharga.Team.Service;
+
+/// <summary>
+/// Decorator that wraps <see cref="IApiKeyAdministrationService"/> and notifies the registered
+/// <see cref="IApiKeyLifecycleHandler"/>(s) after a key is created, recycled, or deleted. The raw
+/// private token (available on the create/refresh result) is forwarded on create/recycle; delete is
+/// signalled tokenless. Read/lock/scope/role operations pass through without notification.
+/// <para>
+/// Handlers run after the underlying mutation succeeds; a handler exception propagates out of the
+/// originating operation (capture failures are not swallowed). The token is never logged.
+/// </para>
+/// </summary>
+public class ApiKeyLifecycleDecorator : IApiKeyAdministrationService
+{
+    private readonly IApiKeyAdministrationService _inner;
+    private readonly IReadOnlyList<IApiKeyLifecycleHandler> _handlers;
+
+    public ApiKeyLifecycleDecorator(IApiKeyAdministrationService inner, IEnumerable<IApiKeyLifecycleHandler> handlers)
+    {
+        _inner = inner;
+        _handlers = handlers?.ToArray() ?? [];
+    }
+
+    // Read operations — pass through
+
+    public Task<IApiKey> GetByApiKeyAsync(string apiKey) => _inner.GetByApiKeyAsync(apiKey);
+    public IAsyncEnumerable<IApiKey> GetKeysAsync(string teamKey) => _inner.GetKeysAsync(teamKey);
+    public IAsyncEnumerable<IApiKey> GetSystemKeysAsync() => _inner.GetSystemKeysAsync();
+
+    // Pass-through mutations (no token change, no lifecycle signal)
+
+    public Task LockKeyAsync(string teamKey, string key) => _inner.LockKeyAsync(teamKey, key);
+    public Task LockSystemKeyAsync(string key) => _inner.LockSystemKeyAsync(key);
+    public Task SetScopeOverridesAsync(string teamKey, string key, string[] scopes) => _inner.SetScopeOverridesAsync(teamKey, key, scopes);
+    public Task SetRolesAsync(string teamKey, string key, string[] roles) => _inner.SetRolesAsync(teamKey, key, roles);
+
+    // Create / recycle — forward the private token
+
+    public async Task<IApiKey> CreateKeyAsync(string teamKey, string name, AccessLevel accessLevel, string[] roles = null, string[] scopeOverrides = null, DateTime? expiryDate = null, IReadOnlyList<Tag> tags = null, string createdBy = null)
+    {
+        var result = await _inner.CreateKeyAsync(teamKey, name, accessLevel, roles, scopeOverrides, expiryDate, tags, createdBy);
+        await NotifyAsync(ApiKeyLifecycleReason.Created, result);
+        return result;
+    }
+
+    public async Task<IApiKey> RefreshKeyAsync(string teamKey, string key)
+    {
+        var result = await _inner.RefreshKeyAsync(teamKey, key);
+        await NotifyAsync(ApiKeyLifecycleReason.Recycled, result);
+        return result;
+    }
+
+    public async Task<IApiKey> CreateSystemKeyAsync(string name, string[] scopes, DateTime? expiryDate = null, string createdBy = null)
+    {
+        var result = await _inner.CreateSystemKeyAsync(name, scopes, expiryDate, createdBy);
+        await NotifyAsync(ApiKeyLifecycleReason.Created, result);
+        return result;
+    }
+
+    public async Task<IApiKey> RefreshSystemKeyAsync(string key)
+    {
+        var result = await _inner.RefreshSystemKeyAsync(key);
+        await NotifyAsync(ApiKeyLifecycleReason.Recycled, result);
+        return result;
+    }
+
+    // Delete — tokenless signal
+
+    public async Task DeleteKeyAsync(string teamKey, string key)
+    {
+        await _inner.DeleteKeyAsync(teamKey, key);
+        await NotifyDeletedAsync(key, teamKey, isSystemKey: false);
+    }
+
+    public async Task DeleteSystemKeyAsync(string key)
+    {
+        await _inner.DeleteSystemKeyAsync(key);
+        await NotifyDeletedAsync(key, teamKey: null, isSystemKey: true);
+    }
+
+    private async Task NotifyAsync(ApiKeyLifecycleReason reason, IApiKey key)
+    {
+        if (_handlers.Count == 0 || key == null) return;
+
+        var context = new ApiKeyLifecycleContext(
+            reason,
+            key.Key,
+            key.ApiKey,
+            key.TeamKey,
+            key.TeamKey == null,
+            key.Name,
+            key.Tags ?? []);
+
+        foreach (var handler in _handlers)
+            await handler.OnApiKeyLifecycleAsync(context);
+    }
+
+    private async Task NotifyDeletedAsync(string apiKeyId, string teamKey, bool isSystemKey)
+    {
+        if (_handlers.Count == 0) return;
+
+        var context = new ApiKeyLifecycleContext(
+            ApiKeyLifecycleReason.Deleted,
+            apiKeyId,
+            PrivateToken: null,
+            teamKey,
+            isSystemKey,
+            Name: null,
+            Tags: []);
+
+        foreach (var handler in _handlers)
+            await handler.OnApiKeyLifecycleAsync(context);
+    }
+}

--- a/Tharga.Team.Service/ApiKeyLifecycleRegistration.cs
+++ b/Tharga.Team.Service/ApiKeyLifecycleRegistration.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Tharga.Team;
+
+namespace Tharga.Team.Service;
+
+/// <summary>
+/// Registration for opt-in API key lifecycle hooks (<see cref="IApiKeyLifecycleHandler"/>).
+/// </summary>
+public static class ApiKeyLifecycleRegistration
+{
+    /// <summary>
+    /// Registers an <see cref="IApiKeyLifecycleHandler"/> and decorates <see cref="IApiKeyAdministrationService"/>
+    /// so the handler is invoked on key create / recycle / delete. Call this <b>after</b> the API key services
+    /// are registered (e.g. after <c>AddThargaPlatform</c> / <c>AddThargaApiKeys</c>). May be called multiple
+    /// times to register several handlers; the decoration is applied once and all handlers are invoked.
+    /// </summary>
+    public static IServiceCollection AddThargaApiKeyLifecycleHandler<THandler>(this IServiceCollection services)
+        where THandler : class, IApiKeyLifecycleHandler
+    {
+        services.AddScoped<IApiKeyLifecycleHandler, THandler>();
+        EnsureDecorated(services);
+        return services;
+    }
+
+    private sealed class LifecycleDecorationMarker;
+
+    private static void EnsureDecorated(IServiceCollection services)
+    {
+        // Apply the decoration exactly once, regardless of how many handlers are registered —
+        // the single decorator resolves all IApiKeyLifecycleHandler instances at runtime.
+        if (services.Any(d => d.ServiceType == typeof(LifecycleDecorationMarker))) return;
+        services.AddSingleton<LifecycleDecorationMarker>();
+
+        var existing = services.LastOrDefault(d => d.ServiceType == typeof(IApiKeyAdministrationService))
+            ?? throw new InvalidOperationException(
+                "AddThargaApiKeyLifecycleHandler must be called after the API key services are registered " +
+                "(e.g. after AddThargaPlatform / AddThargaApiKeys).");
+
+        services.Remove(existing);
+        services.AddScoped<IApiKeyAdministrationService>(sp =>
+        {
+            var inner = ResolveInner(sp, existing);
+            var handlers = sp.GetServices<IApiKeyLifecycleHandler>();
+            return new ApiKeyLifecycleDecorator(inner, handlers);
+        });
+    }
+
+    private static IApiKeyAdministrationService ResolveInner(IServiceProvider sp, ServiceDescriptor existing)
+    {
+        if (existing.ImplementationFactory != null)
+            return (IApiKeyAdministrationService)existing.ImplementationFactory(sp);
+        if (existing.ImplementationInstance != null)
+            return (IApiKeyAdministrationService)existing.ImplementationInstance;
+        if (existing.ImplementationType != null)
+            return (IApiKeyAdministrationService)ActivatorUtilities.CreateInstance(sp, existing.ImplementationType);
+
+        throw new InvalidOperationException("Cannot resolve inner IApiKeyAdministrationService — no factory, instance, or type.");
+    }
+}

--- a/Tharga.Team/ApiKeyLifecycleContext.cs
+++ b/Tharga.Team/ApiKeyLifecycleContext.cs
@@ -1,0 +1,24 @@
+namespace Tharga.Team;
+
+/// <summary>
+/// Information handed to an <see cref="IApiKeyLifecycleHandler"/> when an API key is created,
+/// recycled, or deleted. On <see cref="ApiKeyLifecycleReason.Created"/> and
+/// <see cref="ApiKeyLifecycleReason.Recycled"/> the <see cref="PrivateToken"/> carries the raw key
+/// value — the only moment it is available programmatically. The host is responsible for protecting
+/// anything it captures; Tharga Team never persists, logs, or exposes the token elsewhere.
+/// </summary>
+/// <param name="Reason">Why the handler is being invoked.</param>
+/// <param name="ApiKeyId">Stable public identifier of the key (<see cref="IApiKey.Key"/>). Use this to correlate a host-side copy.</param>
+/// <param name="PrivateToken">The raw API key value. Non-null on <see cref="ApiKeyLifecycleReason.Created"/>/<see cref="ApiKeyLifecycleReason.Recycled"/>; null on <see cref="ApiKeyLifecycleReason.Deleted"/>.</param>
+/// <param name="TeamKey">Owning team, or null for system keys.</param>
+/// <param name="IsSystemKey">True for system (team-less) keys.</param>
+/// <param name="Name">Human-readable key name. Null on <see cref="ApiKeyLifecycleReason.Deleted"/>.</param>
+/// <param name="Tags">System-set tags on the key. Empty on <see cref="ApiKeyLifecycleReason.Deleted"/>.</param>
+public record ApiKeyLifecycleContext(
+    ApiKeyLifecycleReason Reason,
+    string ApiKeyId,
+    string PrivateToken,
+    string TeamKey,
+    bool IsSystemKey,
+    string Name,
+    IReadOnlyList<Tag> Tags);

--- a/Tharga.Team/ApiKeyLifecycleReason.cs
+++ b/Tharga.Team/ApiKeyLifecycleReason.cs
@@ -1,0 +1,16 @@
+namespace Tharga.Team;
+
+/// <summary>
+/// Why an <see cref="IApiKeyLifecycleHandler"/> is being invoked.
+/// </summary>
+public enum ApiKeyLifecycleReason
+{
+    /// <summary>A new key was created. The private token is available.</summary>
+    Created,
+
+    /// <summary>An existing key's secret was regenerated (recycled). The new private token is available.</summary>
+    Recycled,
+
+    /// <summary>A key was deleted. No token is provided; use it to purge any host-side copy.</summary>
+    Deleted,
+}

--- a/Tharga.Team/IApiKeyLifecycleHandler.cs
+++ b/Tharga.Team/IApiKeyLifecycleHandler.cs
@@ -1,0 +1,20 @@
+namespace Tharga.Team;
+
+/// <summary>
+/// Opt-in hook that receives an API key's private token at the moment it exists — on create and on
+/// recycle/regenerate — plus a tokenless signal on delete. Register one or more implementations with
+/// <c>AddThargaApiKeyLifecycleHandler&lt;T&gt;()</c>; they are invoked after the corresponding
+/// operation succeeds.
+/// <para>
+/// The token is handed only to in-process code the host explicitly registered. If the handler throws,
+/// the originating operation (create/recycle/delete) throws too — capture failures are not swallowed.
+/// </para>
+/// </summary>
+public interface IApiKeyLifecycleHandler
+{
+    /// <summary>
+    /// Invoked after an API key is created, recycled, or deleted. See <see cref="ApiKeyLifecycleContext"/>
+    /// for what is available per <see cref="ApiKeyLifecycleReason"/>.
+    /// </summary>
+    Task OnApiKeyLifecycleAsync(ApiKeyLifecycleContext context);
+}

--- a/docs/articles/implementation-guide.md
+++ b/docs/articles/implementation-guide.md
@@ -656,6 +656,38 @@ await apiKeyManagementService.CreateKeyAsync(
 - **Displayed read-only.** `ApiKeyView` shows all tags in an `(i)` tooltip; pass `ChipTagKeys` to render selected keys as chips (e.g. `ChipTagKeys="@(new[] { "Type" })"`).
 - **Legacy data.** Pre-tags keys stored an empty `Tags` document; reads tolerate this automatically (it deserializes as no tags). To purge the legacy field, call `IApiKeyRepository.CleanLegacyTagsAsync()` once (server-side, safe to repeat).
 
+### Lifecycle hook (capturing the private token)
+
+The private API token is shown once at creation and is otherwise unrecoverable — it's never persisted, logged, or exposed programmatically. If a host needs to **capture and re-deliver** a key (e.g. minting a scoped key to hand out repeatedly), register an `IApiKeyLifecycleHandler`. It receives the token at the moment it exists — on **create** and **recycle/regenerate** — plus a tokenless **delete** signal so the host can purge its own copy.
+
+```csharp
+public class MyApiKeyHandler(ISecretProtector protector, IMyKeyStore store) : IApiKeyLifecycleHandler
+{
+    public async Task OnApiKeyLifecycleAsync(ApiKeyLifecycleContext ctx)
+    {
+        switch (ctx.Reason)
+        {
+            case ApiKeyLifecycleReason.Created:
+            case ApiKeyLifecycleReason.Recycled:
+                await store.SaveAsync(ctx.ApiKeyId, protector.Protect(ctx.PrivateToken), ctx.TeamKey, ctx.Tags);
+                break;
+            case ApiKeyLifecycleReason.Deleted:
+                await store.RemoveAsync(ctx.ApiKeyId);
+                break;
+        }
+    }
+}
+
+// after AddThargaPlatform / AddThargaApiKeys:
+builder.Services.AddThargaApiKeyLifecycleHandler<MyApiKeyHandler>();
+```
+
+- **What you get** — `ApiKeyLifecycleContext`: `Reason`, `ApiKeyId` (the stable public id), `PrivateToken` (non-null on Created/Recycled, null on Deleted), `TeamKey` (null for system keys), `IsSystemKey`, `Name`, `Tags`. Applies to both team and system keys.
+- **Error policy** — if the handler throws, the originating `CreateKey`/`RefreshKey`/`DeleteKey` throws too (capture failures are not swallowed). Note this does **not** roll back: a thrown create still leaves the key in storage and a thrown recycle has already rotated the secret — treat a failure as "operation failed" and reconcile (re-recycle, or delete the orphan).
+- **Scope** — fires only on explicit create/recycle/delete. Simple-mode *auto-generated* keys (created lazily by `GetKeysAsync`) and lock/scope/role edits do **not** fire it.
+- **Security** — the token is handed only to in-process handlers you registered; it is still never persisted or logged by the platform. You own whatever you capture (encrypt it at rest).
+- Multiple handlers can be registered; all are invoked.
+
 ### Verification
 
 Create an API key via the UI, then call your API with `X-API-KEY: <key>` header. The request should authenticate successfully.


### PR DESCRIPTION
Closes #83.

## What
An **opt-in, in-process hook** that hands an API key's private token to host code at the moment it exists — on **create** and **recycle/regenerate** — plus a tokenless **delete** signal so the host can purge its own copy. This unblocks the Quilt4Net value-group scenario (mint a scoped key, store it encrypted, re-deliver on demand) **without weakening the platform's posture**: the token is still never persisted, logged, or exposed over any API.

## Design (confirmed up front)
- **Shape:** a DI-resolved `IApiKeyLifecycleHandler` (not an options callback) — idiomatic, testable, multiple handlers.
- **Error policy:** **propagate** — if a handler throws, the create/recycle/delete operation throws too (capture failures aren't swallowed).
- **Signals:** `Created`, `Recycled`, `Deleted` (last is tokenless).

## How it works
A decorator over `IApiKeyAdministrationService` (mirrors the existing `AuditingApiKeyServiceDecorator`) notifies handlers after each successful mutation; the raw token rides on the create/refresh result (`IApiKey.ApiKey`), so no change to the core service. Composes with the audit decorator.

```csharp
public class MyHandler(ISecretProtector p, IMyStore s) : IApiKeyLifecycleHandler
{
    public Task OnApiKeyLifecycleAsync(ApiKeyLifecycleContext ctx) => ctx.Reason switch
    {
        ApiKeyLifecycleReason.Deleted => s.RemoveAsync(ctx.ApiKeyId),
        _ => s.SaveAsync(ctx.ApiKeyId, p.Protect(ctx.PrivateToken), ctx.TeamKey, ctx.Tags),
    };
}

builder.Services.AddThargaApiKeyLifecycleHandler<MyHandler>(); // after AddThargaPlatform/AddThargaApiKeys
```

## New public API (Tharga.Team)
- `IApiKeyLifecycleHandler`, `ApiKeyLifecycleContext` (Reason, ApiKeyId, PrivateToken, TeamKey, IsSystemKey, Name, Tags), `ApiKeyLifecycleReason`.
- `ApiKeyLifecycleDecorator` + `AddThargaApiKeyLifecycleHandler<T>()` (Tharga.Team.Service).

## Known limitations (documented)
- **Propagate ≠ rollback:** a thrown create still leaves the key in storage; a thrown recycle has already rotated the secret. Treat a failure as 'operation failed' and reconcile.
- Simple-mode **auto-generated** keys and lock/scope/role edits do **not** fire the hook (targets explicit create/recycle/delete).
- `Deleted` carries id + team + isSystem only (host keys its side-store by id).

## Tests / docs
12 new tests (per-reason context incl. system variants, no-fire paths, exception propagation, multi-handler, registration/decoration). Service **222** ✓; full solution builds clean. Implementation guide gains an 'API-key lifecycle hook' subsection.

Rebased onto master after #84 merged. Additive — ships under `MAJOR_MINOR=3.0`.