### PR TITLE
Register API-key lifecycle handler via AddThargaPlatform

### DIFF
--- a/Tharga.Team.Blazor.Tests/AddThargaPlatformTests.cs
+++ b/Tharga.Team.Blazor.Tests/AddThargaPlatformTests.cs
@@ -182,6 +182,24 @@ public class AddThargaPlatformTests
     }
 
     [Fact]
+    public void AddApiKeyLifecycleHandler_RegistersHandler_And_Decorates()
+    {
+        var builder = CreateBuilder();
+        builder.AddThargaPlatform(o => o.AddApiKeyLifecycleHandler<TestLifecycleHandler>());
+
+        Assert.Contains(builder.Services, d =>
+            d.ServiceType == typeof(IApiKeyLifecycleHandler) && d.ImplementationType == typeof(TestLifecycleHandler));
+        // Decoration replaces the IApiKeyAdministrationService registration with a factory.
+        var admin = Assert.Single(builder.Services.Where(d => d.ServiceType == typeof(IApiKeyAdministrationService)));
+        Assert.NotNull(admin.ImplementationFactory);
+    }
+
+    private sealed class TestLifecycleHandler : IApiKeyLifecycleHandler
+    {
+        public Task OnApiKeyLifecycleAsync(ApiKeyLifecycleContext context) => Task.CompletedTask;
+    }
+
+    [Fact]
     public void SkipsApiKeyAuth_WhenNull()
     {
         var builder = CreateBuilder();

--- a/Tharga.Team.Blazor/Framework/ThargaPlatformOptions.cs
+++ b/Tharga.Team.Blazor/Framework/ThargaPlatformOptions.cs
@@ -13,6 +13,7 @@ namespace Tharga.Team.Blazor.Framework;
 public class ThargaPlatformOptions
 {
     internal Type _emailSenderType;
+    internal readonly List<Type> _apiKeyLifecycleHandlers = [];
 
     /// <summary>
     /// Options for the Blazor UI layer (title, team service types, auth state decoration).
@@ -77,5 +78,15 @@ public class ThargaPlatformOptions
     public void AddEmailService<T>() where T : class, ITeamEmailSender
     {
         _emailSenderType = typeof(T);
+    }
+
+    /// <summary>
+    /// Register a handler that receives an API key's private token on create and recycle/regenerate,
+    /// plus a tokenless signal on delete (see <see cref="IApiKeyLifecycleHandler"/>). May be called
+    /// multiple times to register several handlers. Requires <see cref="ApiKey"/> to be set.
+    /// </summary>
+    public void AddApiKeyLifecycleHandler<THandler>() where THandler : class, IApiKeyLifecycleHandler
+    {
+        _apiKeyLifecycleHandlers.Add(typeof(THandler));
     }
 }

--- a/Tharga.Team.Blazor/Framework/ThargaPlatformRegistration.cs
+++ b/Tharga.Team.Blazor/Framework/ThargaPlatformRegistration.cs
@@ -66,6 +66,13 @@ public static class ThargaPlatformRegistration
             o._claimsEnricher = options.Blazor._claimsEnricher;
         }, builder.Configuration);
 
+        // API key lifecycle handlers (opt-in) — wrap IApiKeyAdministrationService once and register the
+        // handlers. Done after the API key + audit registration above so the decorator composes on top.
+        foreach (var handlerType in options._apiKeyLifecycleHandlers)
+        {
+            builder.Services.AddThargaApiKeyLifecycleHandler(handlerType);
+        }
+
         // Controllers + Swagger
         if (options.Controllers != null)
         {

--- a/Tharga.Team.Service/ApiKeyLifecycleRegistration.cs
+++ b/Tharga.Team.Service/ApiKeyLifecycleRegistration.cs
@@ -5,20 +5,31 @@ using Tharga.Team;
 namespace Tharga.Team.Service;
 
 /// <summary>
-/// Registration for opt-in API key lifecycle hooks (<see cref="IApiKeyLifecycleHandler"/>).
+/// Internal registration for opt-in API key lifecycle hooks (<see cref="IApiKeyLifecycleHandler"/>).
+/// Consumers register handlers through <c>ThargaPlatformOptions.AddApiKeyLifecycleHandler&lt;T&gt;()</c>,
+/// not by calling these methods directly.
 /// </summary>
-public static class ApiKeyLifecycleRegistration
+internal static class ApiKeyLifecycleRegistration
 {
     /// <summary>
     /// Registers an <see cref="IApiKeyLifecycleHandler"/> and decorates <see cref="IApiKeyAdministrationService"/>
-    /// so the handler is invoked on key create / recycle / delete. Call this <b>after</b> the API key services
-    /// are registered (e.g. after <c>AddThargaPlatform</c> / <c>AddThargaApiKeys</c>). May be called multiple
-    /// times to register several handlers; the decoration is applied once and all handlers are invoked.
+    /// so the handler is invoked on key create / recycle / delete. Called after the API key services are
+    /// registered. May be called multiple times; the decoration is applied once and all handlers are invoked.
     /// </summary>
-    public static IServiceCollection AddThargaApiKeyLifecycleHandler<THandler>(this IServiceCollection services)
+    internal static IServiceCollection AddThargaApiKeyLifecycleHandler<THandler>(this IServiceCollection services)
         where THandler : class, IApiKeyLifecycleHandler
+        => services.AddThargaApiKeyLifecycleHandler(typeof(THandler));
+
+    /// <summary>
+    /// Non-generic overload of <see cref="AddThargaApiKeyLifecycleHandler{THandler}"/>.
+    /// </summary>
+    internal static IServiceCollection AddThargaApiKeyLifecycleHandler(this IServiceCollection services, Type handlerType)
     {
-        services.AddScoped<IApiKeyLifecycleHandler, THandler>();
+        ArgumentNullException.ThrowIfNull(handlerType);
+        if (!typeof(IApiKeyLifecycleHandler).IsAssignableFrom(handlerType))
+            throw new ArgumentException($"{handlerType.Name} must implement {nameof(IApiKeyLifecycleHandler)}.", nameof(handlerType));
+
+        services.AddScoped(typeof(IApiKeyLifecycleHandler), handlerType);
         EnsureDecorated(services);
         return services;
     }

--- a/Tharga.Team.Service/Tharga.Team.Service.csproj
+++ b/Tharga.Team.Service/Tharga.Team.Service.csproj
@@ -42,4 +42,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Team\Tharga.Team.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- API-key lifecycle registration is internal; AddThargaPlatform (Blazor) wires it and tests exercise it. -->
+    <InternalsVisibleTo Include="Tharga.Team.Blazor" />
+    <InternalsVisibleTo Include="Tharga.Team.Service.Tests" />
+  </ItemGroup>
 </Project>

--- a/docs/articles/implementation-guide.md
+++ b/docs/articles/implementation-guide.md
@@ -678,8 +678,12 @@ public class MyApiKeyHandler(ISecretProtector protector, IMyKeyStore store) : IA
     }
 }
 
-// after AddThargaPlatform / AddThargaApiKeys:
-builder.Services.AddThargaApiKeyLifecycleHandler<MyApiKeyHandler>();
+// register it inside AddThargaPlatform:
+builder.AddThargaPlatform(o =>
+{
+    // ...
+    o.AddApiKeyLifecycleHandler<MyApiKeyHandler>();   // may be called multiple times
+});
 ```
 
 - **What you get** — `ApiKeyLifecycleContext`: `Reason`, `ApiKeyId` (the stable public id), `PrivateToken` (non-null on Created/Recycled, null on Deleted), `TeamKey` (null for system keys), `IsSystemKey`, `Name`, `Tags`. Applies to both team and system keys.


### PR DESCRIPTION
Follow-up to #85 (already merged).

Adds **`ThargaPlatformOptions.AddApiKeyLifecycleHandler<T>()`** so a lifecycle handler is registered *inside* `AddThargaPlatform`, consistent with `AddClaimsEnricher` / `AddEmailService`:

```csharp
builder.AddThargaPlatform(o =>
{
    o.Blazor.RegisterTeamService<MyTeamService, MyUserService>();
    o.AddApiKeyLifecycleHandler<MyApiKeyHandler>();   // may be called multiple times
});
```

- The option collects handler types and wires them after the API key + audit registration, so the lifecycle decorator composes on top of the audit decorator (single decoration, all handlers invoked).
- `AddThargaApiKeyLifecycleHandler` gains a non-generic `(Type)` overload used by the platform wiring; the generic `IServiceCollection` extension stays for non-`AddThargaPlatform` setups.
- Docs updated to show the platform-option usage as primary; added an `AddThargaPlatform` registration test.

Service **222** ✓, Blazor **103** ✓ (+1), solution builds clean. Additive — ships under `MAJOR_MINOR=3.0`.