### PR TITLE
Fix: API-key management not audited (order-dependent registration) — closes #87

### DIFF
--- a/Tharga.Team.Blazor.Tests/AddThargaPlatformTests.cs
+++ b/Tharga.Team.Blazor.Tests/AddThargaPlatformTests.cs
@@ -200,6 +200,20 @@ public class AddThargaPlatformTests
     }
 
     [Fact]
+    public void ApiKeyAdministrationService_RegisteredOnce_AsAuditedFactory()
+    {
+        // Regression for #87: AddThargaApiKeyAuthentication must not clobber the audit-decorated
+        // registration. The audited helper registers a single resolve-time factory (not a plain
+        // ImplementationType map), so audit can never be silently dropped by call order.
+        var builder = CreateBuilder();
+        builder.AddThargaPlatform(o => o.Audit = new AuditOptions());
+
+        var admin = Assert.Single(builder.Services.Where(d => d.ServiceType == typeof(IApiKeyAdministrationService)));
+        Assert.NotNull(admin.ImplementationFactory);
+        Assert.Null(admin.ImplementationType);
+    }
+
+    [Fact]
     public void SkipsApiKeyAuth_WhenNull()
     {
         var builder = CreateBuilder();

--- a/Tharga.Team.Blazor/Framework/ThargaBlazorRegistration.cs
+++ b/Tharga.Team.Blazor/Framework/ThargaBlazorRegistration.cs
@@ -50,8 +50,7 @@ public static class ThargaBlazorRegistration
 
             if (o._apiKeyService != null)
             {
-                services.AddScoped(o._apiKeyService);
-                services.AddScoped(typeof(IApiKeyAdministrationService), sp => sp.GetRequiredService(o._apiKeyService));
+                services.AddAuditedApiKeyAdministrationService(o._apiKeyService);
             }
 
             // Register default team and API key scopes unless already registered
@@ -103,24 +102,14 @@ public static class ThargaBlazorRegistration
             }
         }
 
-        if (o._apiKeyService != null)
-        {
-            services.AddScoped(o._apiKeyService);
-            services.AddScoped(typeof(IApiKeyAdministrationService), sp => sp.GetRequiredService(o._apiKeyService));
-        }
-
-        // Audit decorators — wrap ITeamService and IApiKeyAdministrationService when audit logging is configured.
-        // Uses deferred resolution so AddThargaAuditLogging() can be called after AddThargaTeamBlazor().
+        // Audit decorator for ITeamService — wrap when audit logging is configured. Uses deferred
+        // resolution so AddThargaAuditLogging() can be called after AddThargaTeamBlazor().
+        // (IApiKeyAdministrationService audit is owned by AddAuditedApiKeyAdministrationService, applied
+        //  at resolve time, so it is order-independent and not clobbered by AddThargaApiKeyAuthentication.)
         if (o._teamService != null)
         {
             DecorateWithAudit<ITeamService>(services,
                 (inner, logger, http) => new AuditingTeamServiceDecorator(inner, logger, http));
-        }
-
-        if (o._apiKeyService != null)
-        {
-            DecorateWithAudit<IApiKeyAdministrationService>(services,
-                (inner, logger, http) => new AuditingApiKeyServiceDecorator(inner, logger, http));
         }
 
         services.AddSingleton(Options.Create(o));

--- a/Tharga.Team.Service.Tests/ApiKeyAuditWiringTests.cs
+++ b/Tharga.Team.Service.Tests/ApiKeyAuditWiringTests.cs
@@ -1,0 +1,63 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Tharga.Team.Service.Audit;
+using Tharga.Toolkit.Password;
+
+namespace Tharga.Team.Service.Tests;
+
+public class ApiKeyAuditWiringTests
+{
+    private static ServiceCollection BaseServices()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(Substitute.For<IApiKeyRepository>());
+        services.AddSingleton(Substitute.For<IApiKeyService>());
+        services.AddSingleton(Substitute.For<IHttpContextAccessor>());
+        return services;
+    }
+
+    private static void AddAudit(ServiceCollection services)
+    {
+        services.AddSingleton(Options.Create(new AuditOptions()));
+        services.AddSingleton<CompositeAuditLogger>();
+    }
+
+    [Fact]
+    public void AuditedRegistration_WrapsWithAuditDecorator_WhenAuditConfigured()
+    {
+        var services = BaseServices();
+        AddAudit(services);
+        services.AddAuditedApiKeyAdministrationService(typeof(ApiKeyAdministrationService));
+
+        var resolved = services.BuildServiceProvider().GetRequiredService<IApiKeyAdministrationService>();
+
+        Assert.IsType<AuditingApiKeyServiceDecorator>(resolved);
+    }
+
+    [Fact]
+    public void AuditedRegistration_ReturnsPlainService_WhenAuditNotConfigured()
+    {
+        var services = BaseServices();
+        services.AddAuditedApiKeyAdministrationService(typeof(ApiKeyAdministrationService));
+
+        var resolved = services.BuildServiceProvider().GetRequiredService<IApiKeyAdministrationService>();
+
+        Assert.IsType<ApiKeyAdministrationService>(resolved);
+    }
+
+    [Fact]
+    public void AuditedRegistration_StaysAudited_WhenRegisteredAgainAfterwards()
+    {
+        // Regression for #87: a second entry point registering the service must not discard the audit
+        // decorator, and there must be no leftover duplicate registration.
+        var services = BaseServices();
+        AddAudit(services);
+        services.AddAuditedApiKeyAdministrationService(typeof(ApiKeyAdministrationService));
+        services.AddAuditedApiKeyAdministrationService(typeof(ApiKeyAdministrationService));
+
+        Assert.Single(services.Where(d => d.ServiceType == typeof(IApiKeyAdministrationService)));
+        var resolved = services.BuildServiceProvider().GetRequiredService<IApiKeyAdministrationService>();
+        Assert.IsType<AuditingApiKeyServiceDecorator>(resolved);
+    }
+}

--- a/Tharga.Team.Service/ApiKeyRegistration.cs
+++ b/Tharga.Team.Service/ApiKeyRegistration.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Tharga.Team;
+using Tharga.Team.Service.Audit;
 
 namespace Tharga.Team.Service;
 
@@ -50,8 +52,32 @@ public static class ApiKeyRegistration
             });
         });
 
-        builder.Services.AddScoped<IApiKeyAdministrationService, TService>();
+        builder.Services.AddAuditedApiKeyAdministrationService(typeof(TService));
 
         return builder;
+    }
+
+    /// <summary>
+    /// Registers <paramref name="implementationType"/> as the <see cref="IApiKeyAdministrationService"/>,
+    /// applying the <see cref="AuditingApiKeyServiceDecorator"/> at resolve time when audit logging is
+    /// configured (a <see cref="CompositeAuditLogger"/> is present). This is the single owner of the
+    /// <see cref="IApiKeyAdministrationService"/> registration: it drops any prior registration first, so
+    /// call order between Tharga entry points can no longer discard the audit decorator.
+    /// </summary>
+    internal static void AddAuditedApiKeyAdministrationService(this IServiceCollection services, Type implementationType)
+    {
+        foreach (var descriptor in services.Where(d => d.ServiceType == typeof(IApiKeyAdministrationService)).ToList())
+            services.Remove(descriptor);
+
+        services.AddScoped(implementationType);
+        services.AddScoped(typeof(IApiKeyAdministrationService), sp =>
+        {
+            var inner = (IApiKeyAdministrationService)sp.GetRequiredService(implementationType);
+            var auditLogger = sp.GetService<CompositeAuditLogger>(); // deferred — audit may be added after this registration
+            if (auditLogger == null) return inner;
+
+            var httpContextAccessor = sp.GetRequiredService<IHttpContextAccessor>();
+            return new AuditingApiKeyServiceDecorator(inner, auditLogger, httpContextAccessor);
+        });
     }
 }


### PR DESCRIPTION
Closes #87.

## Problem
API-key management ops (create/recycle/lock/delete) were **not written to the audit log**, while team-service ops were. `IApiKeyAdministrationService` was registered/decorated in several places with **last-wins** semantics:

1. **Clobber** — `AddThargaApiKeyAuthentication` ended with `AddScoped<IApiKeyAdministrationService, TService>()`; called *after* `AddThargaTeamBlazor` (the documented order + the repro), the undecorated registration won and discarded the audit decorator.
2. **Gating gap** — the Blazor api-key audit decoration was gated on `o._apiKeyService != null`, but in the normal `AddThargaPlatform` flow the base service is registered by *auth*, so the decoration was **skipped entirely** even without the clobber.

## Fix
A single internal owner — **`AddAuditedApiKeyAdministrationService(Type)`** — drops any prior `IApiKeyAdministrationService` registration and registers a **resolve-time factory** that applies `AuditingApiKeyServiceDecorator` when a `CompositeAuditLogger` is present (deferred check, so `AddThargaAuditLogging` can still be called afterwards). Both `AddThargaApiKeyAuthentication` and the Blazor custom-service path now route through it; the redundant api-key `DecorateWithAudit` is removed (team-service auditing is unchanged).

Result: api-key audit decoration is **order-independent** and can no longer be dropped — works in the standard `AddThargaPlatform` setup and the step-by-step order alike. No audit configured → plain service, no overhead. The lifecycle-hook decorator still composes on top.

## Tests
- Service: helper wraps with audit when configured / returns plain service when not / **stays audited after a second registration** (the regression) — and leaves a single registration.
- Blazor: `AddThargaPlatform` (with audit) yields exactly one `IApiKeyAdministrationService` registered as a factory (not a clobberable type-map).
- Service **225** ✓, Blazor **104** ✓, solution builds clean (0 warnings).

Bug fix, no public API change. Ships under `MAJOR_MINOR=3.0`. (#88 — audit docs + disable-TTL — is the natural follow-up.)