### PR TITLE
Fix: reveal API key in a dialog on create/regenerate (auto-lock made it invisible)

### DIFF
--- a/Tharga.Team.Blazor/Features/Api/ApiKeyRevealDialog.razor
+++ b/Tharga.Team.Blazor/Features/Api/ApiKeyRevealDialog.razor
@@ -1,0 +1,35 @@
+@using Microsoft.JSInterop
+@inject IJSRuntime Js
+@inject DialogService DialogService
+@inject NotificationService NotificationService
+
+@*
+    Shown once, immediately after an API key is created or regenerated. This is the only time the raw
+    key value is available — it is not stored and cannot be retrieved again (and when auto-lock is on
+    it is locked the moment it's created). Give the user a clear, copyable view with a warning.
+*@
+<RadzenStack Gap="1rem">
+    <RadzenAlert AlertStyle="AlertStyle.Warning" ShowIcon="true" Variant="Variant.Flat" AllowClose="false">
+        Copy this key now. For security it is <b>shown only once</b> and is <b>not stored</b> — you will not be able to retrieve it again. If you lose it, regenerate the key to get a new one.
+    </RadzenAlert>
+
+    <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
+        <RadzenTextBox Value="@ApiKey" ReadOnly="true" Style="width: 100%; font-family: monospace;" />
+        <RadzenButton Icon="content_copy" Text="Copy" Click="@CopyAsync" />
+    </RadzenStack>
+
+    <RadzenStack Orientation="Orientation.Horizontal" JustifyContent="JustifyContent.End">
+        <RadzenButton Text="Done" ButtonStyle="ButtonStyle.Base" Variant="Variant.Flat" Click="@(() => DialogService.Close())" />
+    </RadzenStack>
+</RadzenStack>
+
+@code {
+    /// <summary>The raw API key value to reveal (shown once).</summary>
+    [Parameter] public string ApiKey { get; set; }
+
+    private async Task CopyAsync()
+    {
+        await Js.InvokeVoidAsync("clipboard.copyText", ApiKey);
+        NotificationService.Notify(NotificationSeverity.Success, "API key copied to the clipboard.");
+    }
+}

--- a/Tharga.Team.Blazor/Features/Api/ApiKeyView.razor
+++ b/Tharga.Team.Blazor/Features/Api/ApiKeyView.razor
@@ -311,7 +311,7 @@ else
             _newScopeOverrides = new List<string>();
             _newRoles = new List<string>();
             await ReloadData();
-            ShowKeyOnce(created);
+            await ShowKeyDialogAsync(created);
             NotificationService.Notify(NotificationSeverity.Success, "API key created");
         }
         catch (Exception ex)
@@ -327,18 +327,19 @@ else
 
         var refreshed = await _apiKeyManagementService.RefreshKeyAsync(_selectedTeam.Key, context.Key);
         await ReloadData();
-        ShowKeyOnce(refreshed);
+        await ShowKeyDialogAsync(refreshed);
     }
 
-    private void ShowKeyOnce(IApiKey key)
+    // Reveal the raw key once, immediately after create/regenerate. A dialog (rather than an inline grid
+    // reveal) is required because with AutoLockKeys the key is locked on creation, so the reloaded row
+    // carries no value to reveal — and this is the only moment the secret exists.
+    private async Task ShowKeyDialogAsync(IApiKey key)
     {
         if (key == null || string.IsNullOrEmpty(key.ApiKey)) return;
-        var model = _keys?.FirstOrDefault(k => k.Key == key.Key);
-        if (model != null)
-        {
-            model.VisibleKey = key.ApiKey;
-        }
-        StateHasChanged();
+        await DialogService.OpenAsync<ApiKeyRevealDialog>(
+            $"API key — {key.Name}",
+            new Dictionary<string, object> { [nameof(ApiKeyRevealDialog.ApiKey)] = key.ApiKey },
+            new DialogOptions { Width = "640px", CloseDialogOnOverlayClick = false });
     }
 
     private string GetKeyScopesText(ApiKeyModel context)

--- a/Tharga.Team.Blazor/Features/Api/SystemApiKeyView.razor
+++ b/Tharga.Team.Blazor/Features/Api/SystemApiKeyView.razor
@@ -191,7 +191,7 @@
             _newScopes = Array.Empty<string>();
             _newExpiryDate = null;
             await ReloadData();
-            ShowKeyOnce(created);
+            await ShowKeyDialogAsync(created);
             NotificationService.Notify(NotificationSeverity.Success, "System API key created");
         }
         catch (Exception ex)
@@ -207,15 +207,18 @@
 
         var refreshed = await _apiKeyManagementService.RefreshSystemKeyAsync(context.Key);
         await ReloadData();
-        ShowKeyOnce(refreshed);
+        await ShowKeyDialogAsync(refreshed);
     }
 
-    private void ShowKeyOnce(IApiKey key)
+    // Reveal the raw key once via a dialog — required because with AutoLockKeys the key is locked on
+    // creation, so the reloaded row carries no value, and this is the only moment the secret exists.
+    private async Task ShowKeyDialogAsync(IApiKey key)
     {
         if (key == null || string.IsNullOrEmpty(key.ApiKey)) return;
-        var model = _keys?.FirstOrDefault(k => k.Key == key.Key);
-        if (model != null) model.VisibleKey = key.ApiKey;
-        StateHasChanged();
+        await DialogService.OpenAsync<ApiKeyRevealDialog>(
+            $"System API key — {key.Name}",
+            new Dictionary<string, object> { [nameof(ApiKeyRevealDialog.ApiKey)] = key.ApiKey },
+            new DialogOptions { Width = "640px", CloseDialogOnOverlayClick = false });
     }
 
     private void OpenRowMenu(MouseEventArgs args, SystemApiKeyModel context)


### PR DESCRIPTION
## Problem
With `ApiKeyOptions.AutoLockKeys` enabled, **regenerating** (or creating) an API key never showed the new value. `RefreshKeyAsync` locks the key immediately, so the subsequent `ReloadData()` re-fetched the row with an **empty `ApiKey`**. The old inline reveal (`ShowKeyOnce`) set the row's `VisibleKey` to the returned raw value, but the row's `ApiKey` was already empty — so the copy/show affordances were gone and the plaintext just sat in a grid cell (easy to miss, and Radzen may not re-render it). Net effect: the key was effectively unrecoverable.

## Fix
Replace the inline grid reveal with a dedicated **`ApiKeyRevealDialog`**, shown once right after create and regenerate in both `ApiKeyView` and `SystemApiKeyView`:
- the key in a read-only monospace field,
- a **Copy** button (`clipboard.copyText`, the house helper),
- a warning that it is **shown only once and not stored** — regenerate to get a new one if lost.

The raw value comes from the create/refresh **return value** (which carries the secret even when the stored key is auto-locked), so it works regardless of `AutoLockKeys`. The existing per-row "Show value" action for non-locked keys is unchanged.

## Tests / build
Blazor **104** ✓; solution builds clean (0 warnings). (The reveal is a dialog interaction; covered by build + manual.)

Bug fix, no public API change. Ships under `MAJOR_MINOR=3.0`.