### PR TITLE
Audit logging: indefinite retention (disable-able TTL) + docs — closes #88

### DIFF
--- a/Tharga.Team.Service.Tests/AuditRetentionTests.cs
+++ b/Tharga.Team.Service.Tests/AuditRetentionTests.cs
@@ -1,0 +1,45 @@
+using Tharga.Team.Service.Audit;
+
+namespace Tharga.Team.Service.Tests;
+
+public class AuditRetentionTests
+{
+    [Theory]
+    [InlineData(null)]   // unset → keep forever
+    [InlineData(0)]      // was the instant-expiry footgun → now keep forever
+    [InlineData(-5)]     // negative → keep forever
+    public void GetExpireAfter_DisabledRetention_ReturnsNull(int? days)
+    {
+        Assert.Null(AuditRetention.GetExpireAfter(days));
+    }
+
+    [Fact]
+    public void GetExpireAfter_AboveMax_ReturnsNull_NoOverflow()
+    {
+        // int.MaxValue used to overflow TimeSpan.FromDays; now treated as keep-forever.
+        Assert.Null(AuditRetention.GetExpireAfter(int.MaxValue));
+        Assert.Null(AuditRetention.GetExpireAfter(AuditRetention.MaxRetentionDays + 1));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(90)]
+    [InlineData(365)]
+    public void GetExpireAfter_PositiveRetention_ReturnsMatchingTimeSpan(int days)
+    {
+        Assert.Equal(TimeSpan.FromDays(days), AuditRetention.GetExpireAfter(days));
+    }
+
+    [Fact]
+    public void GetExpireAfter_AtMax_ReturnsTimeSpan()
+    {
+        Assert.Equal(TimeSpan.FromDays(AuditRetention.MaxRetentionDays),
+            AuditRetention.GetExpireAfter(AuditRetention.MaxRetentionDays));
+    }
+
+    [Fact]
+    public void AuditOptions_DefaultRetention_Is90()
+    {
+        Assert.Equal(90, new AuditOptions().RetentionDays);
+    }
+}

--- a/Tharga.Team.Service/Audit/AuditOptions.cs
+++ b/Tharga.Team.Service/Audit/AuditOptions.cs
@@ -20,8 +20,13 @@ public class AuditOptions
     /// <summary>Endpoints to exclude from logging (e.g. "/health"). Default: empty.</summary>
     public string[] ExcludedEndpoints { get; set; } = Array.Empty<string>();
 
-    /// <summary>Days to retain audit entries in MongoDB. Default: 90.</summary>
-    public int RetentionDays { get; set; } = 90;
+    /// <summary>
+    /// Days to retain audit entries in MongoDB, applied as a TTL index (<c>Timestamp_TTL</c>). Default: 90.
+    /// <c>null</c> (or any value &lt;= 0) means **keep forever** — no TTL index is created. Note: removing
+    /// or changing the TTL on an existing collection may require dropping the old <c>Timestamp_TTL</c>
+    /// index manually, as MongoDB does not drop it automatically.
+    /// </summary>
+    public int? RetentionDays { get; set; } = 90;
 
     /// <summary>Batch size for background MongoDB writer. Default: 100.</summary>
     public int BatchSize { get; set; } = 100;

--- a/Tharga.Team.Service/Audit/AuditRepositoryCollection.cs
+++ b/Tharga.Team.Service/Audit/AuditRepositoryCollection.cs
@@ -7,7 +7,7 @@ namespace Tharga.Team.Service.Audit;
 
 internal class AuditRepositoryCollection : DiskRepositoryCollectionBase<AuditEntryEntity>, IAuditRepositoryCollection
 {
-    private readonly int _retentionDays;
+    private readonly int? _retentionDays;
 
     public AuditRepositoryCollection(
         IMongoDbServiceFactory mongoDbServiceFactory,
@@ -20,30 +20,42 @@ internal class AuditRepositoryCollection : DiskRepositoryCollectionBase<AuditEnt
 
     public override string CollectionName => "AuditLog";
 
-    public override IEnumerable<CreateIndexModel<AuditEntryEntity>> Indices =>
-    [
-        // TTL index for automatic retention cleanup
-        new(Builders<AuditEntryEntity>.IndexKeys.Ascending(x => x.Timestamp),
-            new CreateIndexOptions { Name = "Timestamp_TTL", ExpireAfter = TimeSpan.FromDays(_retentionDays) }),
+    public override IEnumerable<CreateIndexModel<AuditEntryEntity>> Indices
+    {
+        get
+        {
+            var indices = new List<CreateIndexModel<AuditEntryEntity>>();
 
-        // Compound index for default sort (descending time) with team filter
-        new(Builders<AuditEntryEntity>.IndexKeys
-                .Descending(x => x.Timestamp)
-                .Ascending(x => x.TeamKey),
-            new CreateIndexOptions { Name = "Timestamp_desc_TeamKey" }),
+            // TTL index for automatic retention cleanup — omitted when retention is disabled
+            // (RetentionDays null / <= 0), in which case entries are kept forever.
+            var expireAfter = AuditRetention.GetExpireAfter(_retentionDays);
+            if (expireAfter.HasValue)
+            {
+                indices.Add(new(Builders<AuditEntryEntity>.IndexKeys.Ascending(x => x.Timestamp),
+                    new CreateIndexOptions { Name = "Timestamp_TTL", ExpireAfter = expireAfter.Value }));
+            }
 
-        // Individual indices for $in queries from multi-select filters
-        new(Builders<AuditEntryEntity>.IndexKeys.Ascending(x => x.Feature),
-            new CreateIndexOptions { Name = "Feature" }),
-        new(Builders<AuditEntryEntity>.IndexKeys.Ascending(x => x.Action),
-            new CreateIndexOptions { Name = "Action" }),
-        new(Builders<AuditEntryEntity>.IndexKeys.Ascending(x => x.CallerIdentity),
-            new CreateIndexOptions { Name = "CallerIdentity" }),
-        new(Builders<AuditEntryEntity>.IndexKeys.Ascending(x => x.CallerSource),
-            new CreateIndexOptions { Name = "CallerSource" }),
-        new(Builders<AuditEntryEntity>.IndexKeys.Ascending(x => x.EventType),
-            new CreateIndexOptions { Name = "EventType" }),
-        new(Builders<AuditEntryEntity>.IndexKeys.Ascending(x => x.ScopeChecked),
-            new CreateIndexOptions { Name = "ScopeChecked" }),
-    ];
+            // Compound index for default sort (descending time) with team filter
+            indices.Add(new(Builders<AuditEntryEntity>.IndexKeys
+                    .Descending(x => x.Timestamp)
+                    .Ascending(x => x.TeamKey),
+                new CreateIndexOptions { Name = "Timestamp_desc_TeamKey" }));
+
+            // Individual indices for $in queries from multi-select filters
+            indices.Add(new(Builders<AuditEntryEntity>.IndexKeys.Ascending(x => x.Feature),
+                new CreateIndexOptions { Name = "Feature" }));
+            indices.Add(new(Builders<AuditEntryEntity>.IndexKeys.Ascending(x => x.Action),
+                new CreateIndexOptions { Name = "Action" }));
+            indices.Add(new(Builders<AuditEntryEntity>.IndexKeys.Ascending(x => x.CallerIdentity),
+                new CreateIndexOptions { Name = "CallerIdentity" }));
+            indices.Add(new(Builders<AuditEntryEntity>.IndexKeys.Ascending(x => x.CallerSource),
+                new CreateIndexOptions { Name = "CallerSource" }));
+            indices.Add(new(Builders<AuditEntryEntity>.IndexKeys.Ascending(x => x.EventType),
+                new CreateIndexOptions { Name = "EventType" }));
+            indices.Add(new(Builders<AuditEntryEntity>.IndexKeys.Ascending(x => x.ScopeChecked),
+                new CreateIndexOptions { Name = "ScopeChecked" }));
+
+            return indices;
+        }
+    }
 }

--- a/Tharga.Team.Service/Audit/AuditRetention.cs
+++ b/Tharga.Team.Service/Audit/AuditRetention.cs
@@ -1,0 +1,22 @@
+namespace Tharga.Team.Service.Audit;
+
+/// <summary>
+/// Resolves the MongoDB TTL expiry for audit entries from <see cref="AuditOptions.RetentionDays"/>.
+/// </summary>
+internal static class AuditRetention
+{
+    /// <summary>
+    /// Upper bound for a finite retention. Values above this (and null / non-positive) are treated as
+    /// "keep forever" — both as the intended meaning and to avoid <see cref="TimeSpan.FromDays"/> overflow
+    /// (~10.7M days). ~10,000 years is comfortably below that ceiling.
+    /// </summary>
+    public const int MaxRetentionDays = 3_650_000;
+
+    /// <summary>
+    /// The TTL <c>ExpireAfter</c> for the given retention, or <c>null</c> when retention is disabled
+    /// (<paramref name="retentionDays"/> is null, &lt;= 0, or above <see cref="MaxRetentionDays"/>) — in
+    /// which case no TTL index should be created and entries are kept indefinitely.
+    /// </summary>
+    public static TimeSpan? GetExpireAfter(int? retentionDays)
+        => retentionDays is > 0 and <= MaxRetentionDays ? TimeSpan.FromDays(retentionDays.Value) : null;
+}

--- a/docs/articles/implementation-guide.md
+++ b/docs/articles/implementation-guide.md
@@ -887,23 +887,55 @@ Adds audit logging for service calls, authorization events, and data changes. Lo
 builder.Services.AddThargaAuditLogging();
 ```
 
+> **⚠️ Most common gotcha:** `StorageMode` defaults to **`Logger` only**. The `AuditLogView` component
+> reads from **MongoDB**, so with the default it stays **empty** — entries only go to `ILogger`. To
+> populate the UI you must opt into Mongo storage:
+> ```csharp
+> builder.Services.AddThargaAuditLogging(o => o.StorageMode = AuditStorageMode.MongoDB);
+> // or keep both: AuditStorageMode.Logger | AuditStorageMode.MongoDB
+> ```
+> `AuditStorageMode` is a `[Flags]` enum, so the values combine. MongoDB storage requires MongoDB
+> configured (Step 4).
+
 ### Options
 
 ```csharp
 builder.Services.AddThargaAuditLogging(o =>
 {
-    o.StorageMode = AuditStorageMode.Logger;           // default: Logger — options: Logger, MongoDB, Logger | MongoDB
-    o.CallerFilter = AuditCallerFilter.Api | AuditCallerFilter.Web;  // default: Api | Web
-    o.EventFilter = AuditEventFilter.All;              // default: All
+    o.StorageMode = AuditStorageMode.Logger | AuditStorageMode.MongoDB; // default: Logger only — see gotcha above
+    o.CallerFilter = AuditCallerFilter.Api | AuditCallerFilter.Web;  // default: Api | Web ([Flags])
+    o.EventFilter = AuditEventFilter.All;              // default: All ([Flags])
     o.ExcludedActions = new[] { "read", "list" };      // default: empty — skip noisy read operations
     o.ExcludedEndpoints = Array.Empty<string>();       // default: empty
-    o.RetentionDays = 90;                              // default: 90
-    o.BatchSize = 100;                                 // default: 100 — for MongoDB batch writes
-    o.FlushIntervalSeconds = 5;                        // default: 5 — for MongoDB flush interval
+    o.RetentionDays = 90;                              // default: 90 — null (or <= 0) = keep forever (no TTL)
+    o.BatchSize = 100;                                 // default: 100 — MongoDB background-writer batch size
+    o.FlushIntervalSeconds = 5;                        // default: 5 — MongoDB background-writer flush interval
 });
 ```
 
-> **Note:** To use `AuditStorageMode.MongoDB`, you need MongoDB configured (from Step 4).
+| Option | Default | Notes |
+|---|---|---|
+| `StorageMode` | `Logger` | `[Flags]`: `Logger`, `MongoDB`, or both. **Set `MongoDB` to populate `AuditLogView`.** |
+| `CallerFilter` | `Api \| Web` | `[Flags]` — which caller sources to record. |
+| `EventFilter` | `All` | `[Flags]` — which event types to record. |
+| `ExcludedActions` | empty | Action names to skip (e.g. `"read"`, `"list"`). |
+| `ExcludedEndpoints` | empty | Endpoints to skip (e.g. `"/health"`). |
+| `RetentionDays` | `90` | `int?` mapped to a MongoDB TTL index (`Timestamp_TTL`). **`null` or `<= 0` = keep forever** (no TTL index). |
+| `BatchSize` | `100` | Background MongoDB writer batch size. |
+| `FlushIntervalSeconds` | `5` | Background MongoDB writer flush interval. |
+
+> **Retention / TTL.** `RetentionDays` creates a MongoDB TTL index that auto-deletes entries older than
+> the given age. Set it to **`null`** (or any value `<= 0`) to keep entries **indefinitely** — no TTL
+> index is created. Caveat: MongoDB does not drop an existing TTL index automatically, so changing the
+> retention on a collection that already has a `Timestamp_TTL` index (including switching to "forever")
+> may require dropping that index manually.
+
+### What gets audited
+
+Mutations flow through auditing decorators: **team-service** operations (create/rename/delete team,
+invite/remove member, set consent, …) and **API-key management** (create/recycle/lock/delete, for team
+and system keys). Read operations pass through unaudited; use `ExcludedActions` to drop any others you
+consider noise.
 
 ### What becomes available
 


### PR DESCRIPTION
Closes #88.

## Part 1 — Retention / TTL (can now keep forever)
`AuditOptions.RetentionDays` is now **`int?`** (default 90). **`null` (or any value `<= 0`) = keep forever** — no `Timestamp_TTL` index is created. Mirrors `ApiKeyOptions.MaxExpiryDays` (`int?`, null = no cap).

- New `AuditRetention.GetExpireAfter(int?)` helper resolves the TTL and returns `null` for disabled / non-positive / over-max retention — removing both footguns: `0` no longer means *instant expiry*, and large values (e.g. `int.MaxValue`) no longer **overflow** `TimeSpan.FromDays`.
- `AuditRepositoryCollection` builds its index set conditionally, including the TTL index only when retention is a finite positive value.
- **Caveat (documented):** MongoDB doesn't drop an existing TTL index automatically, so changing retention on a collection that already has `Timestamp_TTL` (including switching to "forever") may need a manual index drop.

## Part 2 — Documentation (implementation guide, Step 8)
- **Prominent gotcha:** `StorageMode` defaults to **`Logger` only**, so the Mongo-backed `AuditLogView` stays empty until you set `AuditStorageMode.MongoDB`.
- `AuditStorageMode` / `CallerFilter` / `EventFilter` are **`[Flags]`** (combinable).
- Full **`AuditOptions` reference table**, the `RetentionDays` → `Timestamp_TTL` mapping + keep-forever semantics, and the background-writer knobs (`BatchSize`/`FlushIntervalSeconds`).
- **What gets audited:** team-service ops + API-key management (audited via #87) through the auditing decorators.

## Tests / build
`AuditRetentionTests` (8): disabled (null/0/negative) → no TTL; positive → matching TimeSpan; over-max & `int.MaxValue` → no overflow; boundary; default 90. Service **234** ✓; solution builds clean.

`RetentionDays` `int`→`int?` is a minor breaking change to the 3.0.2 property type (int-literal assignments still compile). Ships under `MAJOR_MINOR=3.0`.

Pairs with #87 (api-key audit wiring) and #89/#90.