### PR TITLE
Enforce [RequireScope]/[RequireAccessLevel] in interactive Blazor Server (pluggable principal source) — closes #97

### DIFF
--- a/Tharga.Team.Blazor.Tests/BlazorTeamPrincipalAccessorTests.cs
+++ b/Tharga.Team.Blazor.Tests/BlazorTeamPrincipalAccessorTests.cs
@@ -1,0 +1,78 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Tharga.Team;
+using Tharga.Team.Blazor.Framework;
+using Tharga.Team.Service;
+
+namespace Tharga.Team.Blazor.Tests;
+
+public class BlazorTeamPrincipalAccessorTests
+{
+    private static ClaimsPrincipal Principal(string name)
+        => new(new ClaimsIdentity([new Claim(ClaimTypes.Name, name)], "Test"));
+
+    private sealed class StubAuthStateProvider(ClaimsPrincipal user) : AuthenticationStateProvider
+    {
+        public override Task<AuthenticationState> GetAuthenticationStateAsync()
+            => Task.FromResult(new AuthenticationState(user));
+    }
+
+    [Fact]
+    public async Task Uses_HttpContext_User_When_Present()
+    {
+        var httpUser = Principal("http");
+        var accessor = Mock.Of<IHttpContextAccessor>(a => a.HttpContext == new DefaultHttpContext { User = httpUser });
+        var sut = new BlazorTeamPrincipalAccessor(accessor, new StubAuthStateProvider(Principal("circuit")));
+
+        Assert.Same(httpUser, await sut.GetCurrentAsync());
+    }
+
+    [Fact]
+    public async Task Falls_Back_To_AuthenticationStateProvider_In_Circuit()
+    {
+        var circuitUser = Principal("circuit");
+        var accessor = Mock.Of<IHttpContextAccessor>(); // interactive circuit — HttpContext defaults to null
+        var sut = new BlazorTeamPrincipalAccessor(accessor, new StubAuthStateProvider(circuitUser));
+
+        Assert.Same(circuitUser, await sut.GetCurrentAsync());
+    }
+
+    [Fact]
+    public void AddThargaTeamBlazor_Registers_BlazorTeamPrincipalAccessor()
+    {
+        var services = new ServiceCollection();
+        services.AddThargaTeamBlazor(o => o.RegisterTeamService<FakeTeamService, FakeUserService>());
+
+        var descriptor = Assert.Single(services.Where(d => d.ServiceType == typeof(ITeamPrincipalAccessor)));
+        Assert.Equal(typeof(BlazorTeamPrincipalAccessor), descriptor.ImplementationType);
+    }
+
+    private sealed class FakeUserService(AuthenticationStateProvider asp) : UserServiceBase(asp)
+    {
+        protected override Task<IUser> GetUserAsync(ClaimsPrincipal claimsPrincipal) => Task.FromResult<IUser>(null);
+        protected override async IAsyncEnumerable<IUser> GetAllAsync() { yield break; }
+    }
+
+    private sealed class FakeTeamService(IUserService userService) : TeamServiceBase(userService)
+    {
+        protected override Task SetTeamConsentInternalAsync(string teamKey, string[] consentedRoles, AccessLevel? accessLevel) => Task.CompletedTask;
+        protected override async IAsyncEnumerable<ITeam> GetConsentedTeamsInternalAsync(string[] userRoles) { yield break; }
+        protected override IAsyncEnumerable<ITeam> GetTeamsAsync(IUser user) => throw new NotImplementedException();
+        protected override Task<ITeam> GetTeamAsync(string teamKey) => throw new NotImplementedException();
+        protected override Task<ITeam> CreateTeamAsync(string teamKey, string name, IUser user, string displayName = null) => throw new NotImplementedException();
+        protected override Task SetTeamNameAsync(string teamKey, string name) => throw new NotImplementedException();
+        protected override Task DeleteTeamAsync(string teamKey) => throw new NotImplementedException();
+        protected override Task AddTeamMemberAsync(string teamKey, InviteUserModel model) => throw new NotImplementedException();
+        protected override Task RemoveTeamMemberAsync(string teamKey, string userKey) => throw new NotImplementedException();
+        protected override Task<ITeam> SetTeamMemberInvitationResponseAsync(string teamKey, string userKey, string inviteKey, bool accept) => throw new NotImplementedException();
+        protected override Task SetTeamMemberLastSeenAsync(string teamKey, string userKey) => throw new NotImplementedException();
+        protected override Task<ITeamMember> GetTeamMembersAsync(string teamKey, string userKey) => throw new NotImplementedException();
+        protected override Task SetTeamMemberRoleAsync(string teamKey, string userKey, AccessLevel accessLevel) => throw new NotImplementedException();
+        protected override Task SetTeamMemberTenantRolesAsync(string teamKey, string userKey, string[] tenantRoles) => throw new NotImplementedException();
+        protected override Task SetTeamMemberScopeOverridesAsync(string teamKey, string userKey, string[] scopeOverrides) => throw new NotImplementedException();
+        protected override Task SetTeamMemberNameAsync(string teamKey, string userKey, string name) => throw new NotImplementedException();
+    }
+}

--- a/Tharga.Team.Blazor.Tests/BlazorTeamPrincipalAccessorTests.cs
+++ b/Tharga.Team.Blazor.Tests/BlazorTeamPrincipalAccessorTests.cs
@@ -46,7 +46,7 @@ public class BlazorTeamPrincipalAccessorTests
         var services = new ServiceCollection();
         services.AddThargaTeamBlazor(o => o.RegisterTeamService<FakeTeamService, FakeUserService>());
 
-        var descriptor = Assert.Single(services.Where(d => d.ServiceType == typeof(ITeamPrincipalAccessor)));
+        var descriptor = Assert.Single(services, d => d.ServiceType == typeof(ITeamPrincipalAccessor));
         Assert.Equal(typeof(BlazorTeamPrincipalAccessor), descriptor.ImplementationType);
     }
 

--- a/Tharga.Team.Blazor/Framework/BlazorTeamPrincipalAccessor.cs
+++ b/Tharga.Team.Blazor/Framework/BlazorTeamPrincipalAccessor.cs
@@ -1,0 +1,27 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Http;
+using Tharga.Team.Service;
+
+namespace Tharga.Team.Blazor.Framework;
+
+/// <summary>
+/// <see cref="ITeamPrincipalAccessor"/> for Blazor apps that also expose an HTTP/API surface. Uses the
+/// current <c>HttpContext</c> when one exists (controllers, SSR) and falls back to
+/// <see cref="AuthenticationStateProvider"/> in an interactive circuit (where <c>HttpContext</c> is null),
+/// so a single <c>[RequireScope]</c>/<c>[RequireAccessLevel]</c> enforces both surfaces.
+/// </summary>
+public class BlazorTeamPrincipalAccessor(
+    IHttpContextAccessor httpContextAccessor,
+    AuthenticationStateProvider authenticationStateProvider) : ITeamPrincipalAccessor
+{
+    public async ValueTask<ClaimsPrincipal> GetCurrentAsync()
+    {
+        var httpContext = httpContextAccessor.HttpContext;
+        if (httpContext != null)
+            return httpContext.User;
+
+        var state = await authenticationStateProvider.GetAuthenticationStateAsync();
+        return state.User;
+    }
+}

--- a/Tharga.Team.Blazor/Framework/ThargaBlazorRegistration.cs
+++ b/Tharga.Team.Blazor/Framework/ThargaBlazorRegistration.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Tharga.Blazor.Framework;
@@ -71,6 +72,10 @@ public static class ThargaBlazorRegistration
             // Server-side claims enrichment — always registered, reads selected_team_id cookie
             services.AddHttpContextAccessor();
             services.AddTransient<IClaimsTransformation, TeamServerClaimsTransformation>();
+
+            // Make scope/access-level proxies resolve the caller from the circuit too (not just HttpContext),
+            // so [RequireScope]/[RequireAccessLevel] enforce in interactive Blazor Server as well as on the API.
+            services.Replace(ServiceDescriptor.Scoped<ITeamPrincipalAccessor, BlazorTeamPrincipalAccessor>());
 
             // Custom claims enricher — runs before member lookup and consent evaluation
             if (o._claimsEnricher != null)

--- a/Tharga.Team.Blazor/README.md
+++ b/Tharga.Team.Blazor/README.md
@@ -12,6 +12,7 @@ Team management Blazor components for multi-tenant applications. Works with both
 - **User management** - `UserProfileView`, `UsersView`.
 - **Authentication** - `LoginDisplay` with login/logout and team navigation.
 - **Claims augmentation** - `TeamClaimsAuthenticationStateProvider` adds `TeamKey`, `AccessLevel`, role, and scope claims. Compatible with all hosting models.
+- **Scope enforcement in the circuit** - `AddThargaTeamBlazor` registers a circuit-aware `ITeamPrincipalAccessor`, so `[RequireScope]` / `[RequireAccessLevel]` on services (registered with `AddScopedWithScopes` / `AddScopedWithAccessLevel`) enforce when called from interactive Blazor Server components, not just from controllers/API.
 - **Audit** - `AuditLogView` for viewing audit logs with charts and filtering.
 
 ## Quick Start (recommended)

--- a/Tharga.Team.Service.Tests/ScopeProxyPrincipalAccessorTests.cs
+++ b/Tharga.Team.Service.Tests/ScopeProxyPrincipalAccessorTests.cs
@@ -1,0 +1,82 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Tharga.Team;
+
+namespace Tharga.Team.Service.Tests;
+
+public interface IAsyncScopedTestService
+{
+    [RequireScope("doc:read")]
+    Task<string> ReadAsync();
+
+    [RequireScope("doc:write")]
+    Task WriteAsync();
+}
+
+public class ScopeProxyPrincipalAccessorTests
+{
+    private static ClaimsPrincipal Principal(string teamKey, params string[] scopes)
+    {
+        var claims = new List<Claim>();
+        if (teamKey != null) claims.Add(new Claim(TeamClaimTypes.TeamKey, teamKey));
+        foreach (var s in scopes) claims.Add(new Claim(TeamClaimTypes.Scope, s));
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+    }
+
+    private sealed class FixedPrincipalAccessor(ClaimsPrincipal principal) : ITeamPrincipalAccessor
+    {
+        public ValueTask<ClaimsPrincipal> GetCurrentAsync() => new(principal);
+    }
+
+    private static IAsyncScopedTestService CreateProxy(ClaimsPrincipal principal)
+    {
+        var target = Substitute.For<IAsyncScopedTestService>();
+        target.ReadAsync().Returns(Task.FromResult("read-ok"));
+        target.WriteAsync().Returns(Task.CompletedTask);
+        return ScopeProxy<IAsyncScopedTestService>.Create(target, new FixedPrincipalAccessor(principal));
+    }
+
+    // The circuit case from #97: no HttpContext, principal comes from the accessor (e.g. AuthenticationStateProvider).
+
+    [Fact]
+    public async Task Circuit_With_Required_Scope_Allows_AsyncMethod()
+    {
+        var proxy = CreateProxy(Principal("team-1", "doc:read"));
+        Assert.Equal("read-ok", await proxy.ReadAsync());
+    }
+
+    [Fact]
+    public async Task Circuit_Without_Required_Scope_Denies_AsyncMethod()
+    {
+        var proxy = CreateProxy(Principal("team-1", "doc:read")); // has read, not write
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() => proxy.WriteAsync());
+    }
+
+    [Fact]
+    public async Task Circuit_Without_TeamKey_Denies()
+    {
+        var proxy = CreateProxy(Principal(null, "doc:read"));
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() => proxy.ReadAsync());
+    }
+
+    [Fact]
+    public async Task HttpContextTeamPrincipalAccessor_Returns_HttpContext_User()
+    {
+        var principal = Principal("team-1", "doc:read");
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(new DefaultHttpContext { User = principal });
+
+        var resolved = await new HttpContextTeamPrincipalAccessor(accessor).GetCurrentAsync();
+
+        Assert.Same(principal, resolved);
+    }
+
+    [Fact]
+    public async Task HttpContextTeamPrincipalAccessor_Returns_Null_When_No_Context()
+    {
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns((HttpContext)null);
+
+        Assert.Null(await new HttpContextTeamPrincipalAccessor(accessor).GetCurrentAsync());
+    }
+}

--- a/Tharga.Team.Service/AccessLevelProxy.cs
+++ b/Tharga.Team.Service/AccessLevelProxy.cs
@@ -1,5 +1,5 @@
-using System.Diagnostics;
 using System.Reflection;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Tharga.Team.Service.Audit;
 
@@ -7,24 +7,29 @@ namespace Tharga.Team.Service;
 
 /// <summary>
 /// DispatchProxy that intercepts service method calls and enforces
-/// <see cref="RequireAccessLevelAttribute"/> by reading TeamKey and AccessLevel
-/// claims from HttpContext. Methods without the attribute are blocked (fail-closed).
-/// Logs audit entries when IAuditLogger is available.
+/// <see cref="RequireAccessLevelAttribute"/> by reading TeamKey and AccessLevel claims from the current
+/// principal (resolved via <see cref="ITeamPrincipalAccessor"/>, so it works for both HTTP and interactive
+/// Blazor callers). Methods without the attribute are blocked (fail-closed). Logs audit entries when
+/// IAuditLogger is available.
 /// </summary>
 public class AccessLevelProxy<T> : DispatchProxy where T : class
 {
     private T _target;
-    private IHttpContextAccessor _httpContextAccessor;
+    private ITeamPrincipalAccessor _principalAccessor;
     private IAuditLogger _auditLogger;
 
-    public static T Create(T target, IHttpContextAccessor httpContextAccessor, IAuditLogger auditLogger = null)
+    public static T Create(T target, ITeamPrincipalAccessor principalAccessor, IAuditLogger auditLogger = null)
     {
         var proxy = Create<T, AccessLevelProxy<T>>() as AccessLevelProxy<T>;
         proxy._target = target;
-        proxy._httpContextAccessor = httpContextAccessor;
+        proxy._principalAccessor = principalAccessor;
         proxy._auditLogger = auditLogger;
         return proxy as T;
     }
+
+    /// <summary>Back-compat overload — adapts an <see cref="IHttpContextAccessor"/> to the default accessor.</summary>
+    public static T Create(T target, IHttpContextAccessor httpContextAccessor, IAuditLogger auditLogger = null)
+        => Create(target, new HttpContextTeamPrincipalAccessor(httpContextAccessor), auditLogger);
 
     protected override object Invoke(MethodInfo targetMethod, object[] args)
     {
@@ -34,51 +39,21 @@ public class AccessLevelProxy<T> : DispatchProxy where T : class
                 $"Method '{typeof(T).Name}.{targetMethod.Name}' is missing the [RequireAccessLevel] attribute. " +
                 $"All methods on services registered with AddScopedWithAccessLevel must declare their required access level.");
 
-        var sw = Stopwatch.StartNew();
-
-        try
-        {
-            CheckAccessLevel(attribute.MinimumLevel);
-
-            var result = targetMethod.Invoke(_target, args);
-            sw.Stop();
-
-            LogAudit(attribute.MinimumLevel, targetMethod.Name, sw.ElapsedMilliseconds, true);
-
-            return result;
-        }
-        catch (UnauthorizedAccessException ex)
-        {
-            sw.Stop();
-            LogAudit(attribute.MinimumLevel, targetMethod.Name, sw.ElapsedMilliseconds, false,
-                AuditEventType.AccessLevelDenial, ex.Message);
-            throw;
-        }
-        catch (TargetInvocationException tie)
-        {
-            sw.Stop();
-            LogAudit(attribute.MinimumLevel, targetMethod.Name, sw.ElapsedMilliseconds, false,
-                errorMessage: tie.InnerException?.Message);
-            throw;
-        }
-        catch (Exception ex)
-        {
-            sw.Stop();
-            LogAudit(attribute.MinimumLevel, targetMethod.Name, sw.ElapsedMilliseconds, false,
-                errorMessage: ex.Message);
-            throw;
-        }
+        return ProxyInvoker.Invoke(targetMethod, args, _target, _principalAccessor,
+            enforce: principal => CheckAccessLevel(principal, attribute.MinimumLevel),
+            audit: (principal, ms, success, ex) =>
+            {
+                var eventType = !success && ex is UnauthorizedAccessException ? AuditEventType.AccessLevelDenial : (AuditEventType?)null;
+                LogAudit(principal, attribute.MinimumLevel, targetMethod.Name, ms, success, eventType, success ? null : ex?.Message);
+            });
     }
 
-    private void LogAudit(AccessLevel minimumLevel, string methodName, long durationMs, bool success,
+    private void LogAudit(ClaimsPrincipal user, AccessLevel minimumLevel, string methodName, long durationMs, bool success,
         AuditEventType? eventType = null, string errorMessage = null)
     {
         if (_auditLogger == null) return;
 
-        var user = _httpContextAccessor.HttpContext?.User;
-        var identity = user?.Identity;
-
-        var callerSource = identity?.AuthenticationType switch
+        var callerSource = user?.Identity?.AuthenticationType switch
         {
             ApiKeyConstants.SchemeName => AuditCallerSource.Api,
             "Cookies" or "AuthenticationTypes.Federation" => AuditCallerSource.Web,
@@ -96,10 +71,10 @@ public class AccessLevelProxy<T> : DispatchProxy where T : class
             Success = success,
             ErrorMessage = errorMessage,
             CallerType = callerSource == AuditCallerSource.Api ? AuditCallerType.ApiKey : AuditCallerType.User,
-            CorrelationId = Guid.TryParse(_httpContextAccessor.HttpContext?.TraceIdentifier, out var traceId) ? traceId : Guid.NewGuid(),
-            CallerIdentity = user?.FindFirst(System.Security.Claims.ClaimTypes.Name)?.Value
+            CorrelationId = Guid.NewGuid(),
+            CallerIdentity = user?.FindFirst(ClaimTypes.Name)?.Value
                 ?? user?.FindFirst("preferred_username")?.Value
-                ?? user?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+                ?? user?.FindFirst(ClaimTypes.NameIdentifier)?.Value
                 ?? user?.FindFirst("name")?.Value,
             TeamKey = user?.FindFirst(TeamClaimTypes.TeamKey)?.Value,
             AccessLevel = user?.FindFirst(TeamClaimTypes.AccessLevel)?.Value,
@@ -120,9 +95,8 @@ public class AccessLevelProxy<T> : DispatchProxy where T : class
                ?? methodInfo.GetCustomAttribute<RequireAccessLevelAttribute>();
     }
 
-    private void CheckAccessLevel(AccessLevel minimumLevel)
+    private static void CheckAccessLevel(ClaimsPrincipal user, AccessLevel minimumLevel)
     {
-        var user = _httpContextAccessor.HttpContext?.User;
         var teamKey = user?.FindFirst(TeamClaimTypes.TeamKey)?.Value;
         if (string.IsNullOrEmpty(teamKey))
             throw new UnauthorizedAccessException("No team selected.");

--- a/Tharga.Team.Service/AccessLevelServiceCollectionExtensions.cs
+++ b/Tharga.Team.Service/AccessLevelServiceCollectionExtensions.cs
@@ -1,5 +1,5 @@
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Tharga.Team;
 using Tharga.Team.Service.Audit;
 
@@ -19,13 +19,15 @@ public static class AccessLevelServiceCollectionExtensions
         where TService : class
         where TImplementation : class, TService
     {
+        services.AddHttpContextAccessor();
+        services.TryAddScoped<ITeamPrincipalAccessor, HttpContextTeamPrincipalAccessor>();
         services.AddScoped<TImplementation>();
         services.AddScoped<TService>(sp =>
         {
             var target = sp.GetRequiredService<TImplementation>();
-            var httpContextAccessor = sp.GetRequiredService<IHttpContextAccessor>();
+            var principalAccessor = sp.GetRequiredService<ITeamPrincipalAccessor>();
             var auditLogger = sp.GetService<IAuditLogger>();
-            return AccessLevelProxy<TService>.Create(target, httpContextAccessor, auditLogger);
+            return AccessLevelProxy<TService>.Create(target, principalAccessor, auditLogger);
         });
         return services;
     }

--- a/Tharga.Team.Service/HttpContextTeamPrincipalAccessor.cs
+++ b/Tharga.Team.Service/HttpContextTeamPrincipalAccessor.cs
@@ -1,0 +1,14 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+
+namespace Tharga.Team.Service;
+
+/// <summary>
+/// Default <see cref="ITeamPrincipalAccessor"/> that resolves the caller from the current HTTP request
+/// (<see cref="IHttpContextAccessor"/>). Used for controller/API callers; returns null outside a request.
+/// </summary>
+public class HttpContextTeamPrincipalAccessor(IHttpContextAccessor httpContextAccessor) : ITeamPrincipalAccessor
+{
+    public ValueTask<ClaimsPrincipal> GetCurrentAsync()
+        => new(httpContextAccessor.HttpContext?.User);
+}

--- a/Tharga.Team.Service/ITeamPrincipalAccessor.cs
+++ b/Tharga.Team.Service/ITeamPrincipalAccessor.cs
@@ -1,0 +1,15 @@
+using System.Security.Claims;
+
+namespace Tharga.Team.Service;
+
+/// <summary>
+/// Resolves the current caller's <see cref="ClaimsPrincipal"/> for scope / access-level enforcement.
+/// Abstracting this lets enforcement work outside an HTTP request — e.g. in an interactive Blazor Server
+/// circuit where there is no <c>HttpContext</c> but the principal is available via
+/// <c>AuthenticationStateProvider</c>. The default implementation reads <c>IHttpContextAccessor</c>.
+/// </summary>
+public interface ITeamPrincipalAccessor
+{
+    /// <summary>The current principal, or null when no caller can be resolved.</summary>
+    ValueTask<ClaimsPrincipal> GetCurrentAsync();
+}

--- a/Tharga.Team.Service/ProxyInvoker.cs
+++ b/Tharga.Team.Service/ProxyInvoker.cs
@@ -1,0 +1,117 @@
+using System.Reflection;
+using System.Security.Claims;
+
+namespace Tharga.Team.Service;
+
+/// <summary>
+/// Shared invocation pipeline for the enforcement proxies (<see cref="ScopeProxy{T}"/>,
+/// <see cref="AccessLevelProxy{T}"/>): resolve the caller (possibly asynchronously, e.g. from a Blazor
+/// circuit), run <paramref name="enforce"/>, invoke the target, then <paramref name="audit"/> the outcome.
+/// Handles sync, <see cref="Task"/> and <see cref="Task{TResult}"/> methods so the async principal source
+/// is awaited rather than blocked for the common (async) service methods.
+/// </summary>
+internal static class ProxyInvoker
+{
+    /// <param name="enforce">Throws <see cref="UnauthorizedAccessException"/> if the principal is not allowed.</param>
+    /// <param name="audit">Invoked with (principal, durationMs, success, exception-or-null) after the call.</param>
+    public static object Invoke(
+        MethodInfo method, object[] args, object target,
+        ITeamPrincipalAccessor accessor,
+        Action<ClaimsPrincipal> enforce,
+        Action<ClaimsPrincipal, long, bool, Exception> audit)
+    {
+        var returnType = method.ReturnType;
+
+        if (returnType == typeof(Task))
+            return InvokeAsync(method, args, target, accessor, enforce, audit);
+
+        if (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(Task<>))
+        {
+            var helper = typeof(ProxyInvoker)
+                .GetMethod(nameof(InvokeAsyncGeneric), BindingFlags.NonPublic | BindingFlags.Static)!
+                .MakeGenericMethod(returnType.GetGenericArguments()[0]);
+            return helper.Invoke(null, [method, args, target, accessor, enforce, audit]);
+        }
+
+        return InvokeSync(method, args, target, accessor, enforce, audit);
+    }
+
+    private static object InvokeSync(
+        MethodInfo method, object[] args, object target,
+        ITeamPrincipalAccessor accessor,
+        Action<ClaimsPrincipal> enforce,
+        Action<ClaimsPrincipal, long, bool, Exception> audit)
+    {
+        var principal = accessor.GetCurrentAsync().GetAwaiter().GetResult();
+        var startedAt = StartTimestamp();
+        try
+        {
+            enforce(principal);
+            var result = Unwrap(() => method.Invoke(target, args));
+            audit(principal, ElapsedMs(startedAt), true, null);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            audit(principal, ElapsedMs(startedAt), false, ex);
+            throw;
+        }
+    }
+
+    private static async Task InvokeAsync(
+        MethodInfo method, object[] args, object target,
+        ITeamPrincipalAccessor accessor,
+        Action<ClaimsPrincipal> enforce,
+        Action<ClaimsPrincipal, long, bool, Exception> audit)
+    {
+        var principal = await accessor.GetCurrentAsync();
+        var startedAt = StartTimestamp();
+        try
+        {
+            enforce(principal);
+            await (Task)Unwrap(() => method.Invoke(target, args));
+            audit(principal, ElapsedMs(startedAt), true, null);
+        }
+        catch (Exception ex)
+        {
+            audit(principal, ElapsedMs(startedAt), false, ex);
+            throw;
+        }
+    }
+
+    private static async Task<TResult> InvokeAsyncGeneric<TResult>(
+        MethodInfo method, object[] args, object target,
+        ITeamPrincipalAccessor accessor,
+        Action<ClaimsPrincipal> enforce,
+        Action<ClaimsPrincipal, long, bool, Exception> audit)
+    {
+        var principal = await accessor.GetCurrentAsync();
+        var startedAt = StartTimestamp();
+        try
+        {
+            enforce(principal);
+            var result = await (Task<TResult>)Unwrap(() => method.Invoke(target, args));
+            audit(principal, ElapsedMs(startedAt), true, null);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            audit(principal, ElapsedMs(startedAt), false, ex);
+            throw;
+        }
+    }
+
+    // Reflection wraps target exceptions in TargetInvocationException — surface the real one.
+    private static object Unwrap(Func<object> invoke)
+    {
+        try { return invoke(); }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
+            throw; // unreachable
+        }
+    }
+
+    private static long StartTimestamp() => System.Diagnostics.Stopwatch.GetTimestamp();
+    private static long ElapsedMs(long startedAt) => (long)System.Diagnostics.Stopwatch.GetElapsedTime(startedAt).TotalMilliseconds;
+}

--- a/Tharga.Team.Service/ProxyInvoker.cs
+++ b/Tharga.Team.Service/ProxyInvoker.cs
@@ -6,12 +6,19 @@ namespace Tharga.Team.Service;
 /// <summary>
 /// Shared invocation pipeline for the enforcement proxies (<see cref="ScopeProxy{T}"/>,
 /// <see cref="AccessLevelProxy{T}"/>): resolve the caller (possibly asynchronously, e.g. from a Blazor
-/// circuit), run <paramref name="enforce"/>, invoke the target, then <paramref name="audit"/> the outcome.
+/// circuit), run the <c>enforce</c> check, invoke the target, then <c>audit</c> the outcome.
 /// Handles sync, <see cref="Task"/> and <see cref="Task{TResult}"/> methods so the async principal source
 /// is awaited rather than blocked for the common (async) service methods.
 /// </summary>
 internal static class ProxyInvoker
 {
+    /// <summary>
+    /// Resolves the caller, runs the enforcement check, invokes the target method, then audits the outcome.
+    /// </summary>
+    /// <param name="method">The intercepted interface method to invoke on the target.</param>
+    /// <param name="args">The arguments passed to <paramref name="method"/>.</param>
+    /// <param name="target">The concrete service the proxy wraps.</param>
+    /// <param name="accessor">Resolves the current <see cref="ClaimsPrincipal"/> (sync or async).</param>
     /// <param name="enforce">Throws <see cref="UnauthorizedAccessException"/> if the principal is not allowed.</param>
     /// <param name="audit">Invoked with (principal, durationMs, success, exception-or-null) after the call.</param>
     public static object Invoke(

--- a/Tharga.Team.Service/README.md
+++ b/Tharga.Team.Service/README.md
@@ -10,6 +10,7 @@ Server-side API-key authentication, authorization enforcement, controller regist
 - **API key authentication** - Reads the `X-API-KEY` header, validates against a store, and populates `TeamKey`, `AccessLevel`, and scope claims.
 - **Access level authorization** - `AccessLevelProxy<T>` enforces `[RequireAccessLevel]` on service methods via `DispatchProxy`.
 - **Scope authorization** - `ScopeProxy<T>` enforces `[RequireScope]` with audit logging.
+- **Works in API and interactive Blazor** - the proxies resolve the caller via `ITeamPrincipalAccessor` (default: `IHttpContextAccessor`). `AddThargaTeamBlazor` swaps in a circuit-aware accessor (HttpContext when present, else `AuthenticationStateProvider`), so one `[RequireScope]`/`[RequireAccessLevel]` enforces both surfaces. Register a custom `ITeamPrincipalAccessor` to plug in another principal source.
 - **Controller + Swagger registration** - Single-call setup for MVC controllers, OpenAPI document with API key security scheme, and Swagger UI.
 - **API key management** - Default MongoDB-backed `ApiKeyAdministrationService` with key hashing. Configurable via `ApiKeyOptions` — see [API key options](#api-key-options).
 - **Audit logging** - `CompositeAuditLogger` with `ILogger` and MongoDB backends. ⚠️ Stores to `ILogger` only by default — see [Audit logging](#audit-logging).

--- a/Tharga.Team.Service/ScopeProxy.cs
+++ b/Tharga.Team.Service/ScopeProxy.cs
@@ -1,5 +1,5 @@
-using System.Diagnostics;
 using System.Reflection;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Tharga.Team.Service.Audit;
 using Tharga.Team;
@@ -8,25 +8,29 @@ namespace Tharga.Team.Service;
 
 /// <summary>
 /// DispatchProxy that intercepts service method calls and enforces
-/// <see cref="RequireScopeAttribute"/> by checking scope claims on HttpContext.User.
-/// Methods without the attribute throw InvalidOperationException (fail-closed).
-/// Also verifies that a TeamKey claim is present.
-/// Logs audit entries when IAuditLogger is available.
+/// <see cref="RequireScopeAttribute"/> by checking scope claims on the current principal (resolved via
+/// <see cref="ITeamPrincipalAccessor"/>, so it works for both HTTP and interactive Blazor callers).
+/// Methods without the attribute throw InvalidOperationException (fail-closed). Also verifies a TeamKey
+/// claim is present. Logs audit entries when IAuditLogger is available.
 /// </summary>
 public class ScopeProxy<T> : DispatchProxy where T : class
 {
     private T _target;
-    private IHttpContextAccessor _httpContextAccessor;
+    private ITeamPrincipalAccessor _principalAccessor;
     private IAuditLogger _auditLogger;
 
-    public static T Create(T target, IHttpContextAccessor httpContextAccessor, IAuditLogger auditLogger = null)
+    public static T Create(T target, ITeamPrincipalAccessor principalAccessor, IAuditLogger auditLogger = null)
     {
         var proxy = Create<T, ScopeProxy<T>>() as ScopeProxy<T>;
         proxy._target = target;
-        proxy._httpContextAccessor = httpContextAccessor;
+        proxy._principalAccessor = principalAccessor;
         proxy._auditLogger = auditLogger;
         return proxy as T;
     }
+
+    /// <summary>Back-compat overload — adapts an <see cref="IHttpContextAccessor"/> to the default accessor.</summary>
+    public static T Create(T target, IHttpContextAccessor httpContextAccessor, IAuditLogger auditLogger = null)
+        => Create(target, new HttpContextTeamPrincipalAccessor(httpContextAccessor), auditLogger);
 
     protected override object Invoke(MethodInfo targetMethod, object[] args)
     {
@@ -37,56 +41,28 @@ public class ScopeProxy<T> : DispatchProxy where T : class
                 $"All methods on services registered with AddScopedWithScopes must declare their required scope.");
 
         var (feature, action) = AuditEntry.ParseScope(attribute.Scope);
-        var sw = Stopwatch.StartNew();
 
-        try
-        {
-            CheckScope(attribute.Scope);
-
-            var result = targetMethod.Invoke(_target, args);
-            sw.Stop();
-
-            LogAudit(attribute.Scope, feature, action, targetMethod.Name, sw.ElapsedMilliseconds, true, AuditScopeResult.Allowed);
-
-            return result;
-        }
-        catch (UnauthorizedAccessException ex) when (ex.Message.Contains("Missing required scope"))
-        {
-            sw.Stop();
-            LogAudit(attribute.Scope, feature, action, targetMethod.Name, sw.ElapsedMilliseconds, false, AuditScopeResult.Denied, ex.Message);
-            throw;
-        }
-        catch (TargetInvocationException tie)
-        {
-            sw.Stop();
-            LogAudit(attribute.Scope, feature, action, targetMethod.Name, sw.ElapsedMilliseconds, false, AuditScopeResult.Allowed, tie.InnerException?.Message);
-            throw;
-        }
-        catch (Exception ex)
-        {
-            sw.Stop();
-            LogAudit(attribute.Scope, feature, action, targetMethod.Name, sw.ElapsedMilliseconds, false, AuditScopeResult.Allowed, ex.Message);
-            throw;
-        }
+        return ProxyInvoker.Invoke(targetMethod, args, _target, _principalAccessor,
+            enforce: principal => CheckScope(principal, attribute.Scope),
+            audit: (principal, ms, success, ex) =>
+            {
+                var scopeResult = !success && ex is UnauthorizedAccessException uae && uae.Message.Contains("Missing required scope")
+                    ? AuditScopeResult.Denied
+                    : AuditScopeResult.Allowed;
+                LogAudit(principal, attribute.Scope, feature, action, targetMethod.Name, ms, success, scopeResult, success ? null : ex?.Message);
+            });
     }
 
-    private void LogAudit(string scope, string feature, string action, string methodName, long durationMs, bool success, AuditScopeResult scopeResult, string errorMessage = null)
+    private void LogAudit(ClaimsPrincipal user, string scope, string feature, string action, string methodName, long durationMs, bool success, AuditScopeResult scopeResult, string errorMessage = null)
     {
         if (_auditLogger == null) return;
 
-        var user = _httpContextAccessor.HttpContext?.User;
-        var identity = user?.Identity;
-
-        var callerSource = identity?.AuthenticationType switch
+        var callerSource = user?.Identity?.AuthenticationType switch
         {
             ApiKeyConstants.SchemeName => AuditCallerSource.Api,
             "Cookies" or "AuthenticationTypes.Federation" => AuditCallerSource.Web,
             _ => AuditCallerSource.Unknown
         };
-
-        var callerType = callerSource == AuditCallerSource.Api
-            ? AuditCallerType.ApiKey
-            : AuditCallerType.User;
 
         var entry = new AuditEntry
         {
@@ -98,11 +74,11 @@ public class ScopeProxy<T> : DispatchProxy where T : class
             DurationMs = durationMs,
             Success = success,
             ErrorMessage = errorMessage,
-            CallerType = callerType,
-            CorrelationId = Guid.TryParse(_httpContextAccessor.HttpContext?.TraceIdentifier, out var traceId) ? traceId : Guid.NewGuid(),
-            CallerIdentity = user?.FindFirst(System.Security.Claims.ClaimTypes.Name)?.Value
+            CallerType = callerSource == AuditCallerSource.Api ? AuditCallerType.ApiKey : AuditCallerType.User,
+            CorrelationId = Guid.NewGuid(),
+            CallerIdentity = user?.FindFirst(ClaimTypes.Name)?.Value
                 ?? user?.FindFirst("preferred_username")?.Value
-                ?? user?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+                ?? user?.FindFirst(ClaimTypes.NameIdentifier)?.Value
                 ?? user?.FindFirst("name")?.Value,
             TeamKey = user?.FindFirst(TeamClaimTypes.TeamKey)?.Value,
             AccessLevel = user?.FindFirst(TeamClaimTypes.AccessLevel)?.Value,
@@ -123,10 +99,8 @@ public class ScopeProxy<T> : DispatchProxy where T : class
                ?? methodInfo.GetCustomAttribute<RequireScopeAttribute>();
     }
 
-    private void CheckScope(string requiredScope)
+    private static void CheckScope(ClaimsPrincipal user, string requiredScope)
     {
-        var user = _httpContextAccessor.HttpContext?.User;
-
         var teamKey = user?.FindFirst(TeamClaimTypes.TeamKey)?.Value;
         if (string.IsNullOrEmpty(teamKey))
             throw new UnauthorizedAccessException("No team selected.");

--- a/Tharga.Team.Service/ScopeServiceCollectionExtensions.cs
+++ b/Tharga.Team.Service/ScopeServiceCollectionExtensions.cs
@@ -1,5 +1,5 @@
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Tharga.Team.Service.Audit;
 using Tharga.Team;
 
@@ -74,13 +74,15 @@ public static class ScopeServiceCollectionExtensions
         where TService : class
         where TImplementation : class, TService
     {
+        services.AddHttpContextAccessor();
+        services.TryAddScoped<ITeamPrincipalAccessor, HttpContextTeamPrincipalAccessor>();
         services.AddScoped<TImplementation>();
         services.AddScoped<TService>(sp =>
         {
             var target = sp.GetRequiredService<TImplementation>();
-            var httpContextAccessor = sp.GetRequiredService<IHttpContextAccessor>();
+            var principalAccessor = sp.GetRequiredService<ITeamPrincipalAccessor>();
             var auditLogger = sp.GetService<CompositeAuditLogger>();
-            return ScopeProxy<TService>.Create(target, httpContextAccessor, auditLogger);
+            return ScopeProxy<TService>.Create(target, principalAccessor, auditLogger);
         });
         return services;
     }

--- a/docs/articles/implementation-guide.md
+++ b/docs/articles/implementation-guide.md
@@ -751,6 +751,8 @@ public class MyService : IMyService
 
 The `ScopeProxy<T>` automatically checks that the current user has the required scope before calling the method. If the scope is denied, an `UnauthorizedAccessException` is thrown.
 
+> **Works in interactive Blazor Server too.** The proxy resolves the caller via `ITeamPrincipalAccessor`. The default implementation reads `IHttpContextAccessor` (controllers/API). `AddThargaPlatform` / `AddThargaTeamBlazor` automatically swap in a circuit-aware accessor that uses `HttpContext` when present and falls back to `AuthenticationStateProvider` otherwise — so a single `[RequireScope]` / `[RequireAccessLevel]` enforces both your API and interactive Blazor callers (no `HttpContext` is needed in a circuit). To plug in a different principal source, register your own `ITeamPrincipalAccessor`.
+
 ### How scopes are resolved
 
 1. **Access level** — Owner and Administrator get all scopes. User gets scopes at User or Viewer level. Viewer gets only Viewer-level scopes. **`Custom` gets no base scopes** (and is exempt from the Owner/Administrator "all scopes" rule).


### PR DESCRIPTION
Closes #97.

## Problem
`ScopeProxy<T>` / `AccessLevelProxy<T>` (enforcing `[RequireScope]` / `[RequireAccessLevel]`) read the caller from `IHttpContextAccessor`. In **interactive Blazor Server** there's no `HttpContext` during circuit events, so enforcement misfires (fails closed: "No team selected") for any proxied service called from a component — forcing apps to enforce authorization twice.

## Fix
Make the proxy's **principal source pluggable**, and auto-wire a circuit-aware one for Blazor.

- **`ITeamPrincipalAccessor`** (Tharga.Team.Service) — `ValueTask<ClaimsPrincipal> GetCurrentAsync()`. Default **`HttpContextTeamPrincipalAccessor`** reads `HttpContext.User`.
- **`BlazorTeamPrincipalAccessor`** (Tharga.Team.Blazor) — `HttpContext` when present (controllers/SSR), else `AuthenticationStateProvider` (circuit). `AddThargaTeamBlazor` auto-registers it via `Replace`, so one `[RequireScope]`/`[RequireAccessLevel]` enforces **both API and interactive Blazor** with no extra host wiring.
- **Proxies** resolve the principal via the accessor. A shared **`ProxyInvoker`** awaits the (async) accessor for `Task`/`Task<T>` methods and runs sync methods inline; reflection's `TargetInvocationException` is unwrapped so callers see the real exception.
- **Back-compat:** `Create(IHttpContextAccessor, …)` overloads retained; `AddScopedWithScopes`/`AddScopedWithAccessLevel` signatures unchanged (they `TryAdd` the default accessor). Non-Blazor behaviour is unchanged.

## Tests / build
- Proxy enforcement in the **circuit case** (principal from accessor, no HttpContext) + async `Task<T>` methods; both accessors; the `AddThargaTeamBlazor` auto-wiring.
- Service **253**, Blazor **108**; solution builds clean. Docs updated (implementation guide + Service/Blazor READMEs).

Additive — new public `ITeamPrincipalAccessor`; a minor (3.1) bump is cleanest, or ships under `MAJOR_MINOR=3.0` (→ 3.0.5).
