### PR TITLE
chore: update NuGet packages

### DIFF
--- a/Tharga.Team.Blazor/Tharga.Team.Blazor.csproj
+++ b/Tharga.Team.Blazor/Tharga.Team.Blazor.csproj
@@ -32,12 +32,12 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Web" Version="4.9.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.11.0" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
-    <PackageReference Include="Tharga.Blazor" Version="2.1.6" />
+    <PackageReference Include="Tharga.Blazor" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Team\Tharga.Team.csproj" />

--- a/Tharga.Team.MongoDB/Tharga.Team.MongoDB.csproj
+++ b/Tharga.Team.MongoDB/Tharga.Team.MongoDB.csproj
@@ -28,7 +28,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Tharga.MongoDB" Version="2.11.0" />
+    <PackageReference Include="Tharga.MongoDB" Version="2.11.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Team\Tharga.Team.csproj" />

--- a/Tharga.Team.Service/Tharga.Team.Service.csproj
+++ b/Tharga.Team.Service/Tharga.Team.Service.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
-    <PackageReference Include="Tharga.MongoDB" Version="2.11.0" />
+    <PackageReference Include="Tharga.MongoDB" Version="2.11.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Team\Tharga.Team.csproj" />


### PR DESCRIPTION
## Summary
Updates NuGet packages to their latest in-major releases.

| Package | From → To | Project(s) |
|---|---|---|
| Tharga.MongoDB | 2.11.0 → 2.11.2 | Team.MongoDB, Team.Service |
| Microsoft.Identity.Web | 4.9.0 → 4.11.0 | Team.Blazor |
| Tharga.Blazor | 2.1.6 → 2.2.0 | Team.Blazor |
| Microsoft.AspNetCore.DataProtection | 10.0.8 → 10.0.9 | Team.Blazor (net10) |

Framework-tied `Microsoft.AspNetCore.*` packages on the net9.0 target were left at 9.0.17 (already the latest 9.0.x patch) rather than cross-major bumping to 10.x.

## Testing
- Release build: 0 errors
- All 493 tests pass