### PR TITLE
fix: restore destructive red styling on Delete in API-key context menus

### DIFF
--- a/Tharga.Team.Blazor/Features/Api/ApiKeyView.razor
+++ b/Tharga.Team.Blazor/Features/Api/ApiKeyView.razor
@@ -442,7 +442,7 @@ else
         if (showEdit) items.Add(new ContextMenuItem { Text = "Edit roles & scopes", Icon = "tune", Value = "edit" });
         if (hasValue) items.Add(new ContextMenuItem { Text = "Lock", Icon = "lock", Value = "lock" });
         items.Add(new ContextMenuItem { Text = "Refresh", Icon = "refresh", Value = "refresh" });
-        if (_options.AdvancedMode) items.Add(new ContextMenuItem { Text = "Delete", Icon = "delete", Value = "delete" });
+        if (_options.AdvancedMode) items.Add(new ContextMenuItem { Text = "Delete", Icon = "delete", IconColor = "var(--rz-danger)", Value = "delete" });
 
         ContextMenuService.Open(args, items, async e =>
         {

--- a/Tharga.Team.Blazor/Features/Api/SystemApiKeyView.razor
+++ b/Tharga.Team.Blazor/Features/Api/SystemApiKeyView.razor
@@ -242,7 +242,7 @@
         if (ShowAuditLogButton) items.Add(new ContextMenuItem { Text = "Audit log", Icon = "manage_search", Value = "audit" });
         if (hasValue) items.Add(new ContextMenuItem { Text = "Lock", Icon = "lock", Value = "lock" });
         items.Add(new ContextMenuItem { Text = "Refresh", Icon = "refresh", Value = "refresh" });
-        items.Add(new ContextMenuItem { Text = "Delete", Icon = "delete", Value = "delete" });
+        items.Add(new ContextMenuItem { Text = "Delete", Icon = "delete", IconColor = "var(--rz-danger)", Value = "delete" });
 
         ContextMenuService.Open(args, items, async e =>
         {


### PR DESCRIPTION
## Restore destructive styling on Delete in the API-key context menus

The **Delete** action in the row context menu of `<ApiKeyView />` and `<SystemApiKeyView />` now shows its trash icon in the theme's danger color (`var(--rz-danger)`), restoring the destructive visual emphasis it had before the row actions moved into a Radzen `ContextMenu`.

### Background
When the per-row actions were consolidated into a `ContextMenu`, `ContextMenuItem` had no per-item style, so Delete lost the red `ButtonStyle.Danger` treatment it previously had as an inline button. This colors the Delete icon red per-item — no custom template needed.

### Notes
- Icon-only emphasis: the menu label text is unchanged (Radzen `ContextMenuItem` still exposes no per-item text color without a custom render template).
- Delete remains confirm-gated — no behavioural change.
- Theme-aware: `var(--rz-danger)` renders correctly in both light and dark themes.

No API changes. No consumer action required.
