### PR TITLE
docs: mark the standalone WASM auth path as unverified

### DIFF
--- a/Tharga.Team.Blazor/Framework/ThargaBlazorOptions.cs
+++ b/Tharga.Team.Blazor/Framework/ThargaBlazorOptions.cs
@@ -55,6 +55,13 @@ public record ThargaBlazorOptions : BlazorOptions
     /// apps with no server-side HTTP pipeline. Setting this to false on a Server/SSR app will cause
     /// a blank page (silent deadlock from JS interop during prerendering).
     /// </para>
+    /// <para>
+    /// <b>Note:</b> the <c>false</c> path has never been verified against a real standalone WebAssembly
+    /// app — no WASM sample exists in this repository. Treat it as unproven. Automatic hosting-model
+    /// detection was investigated so this option could be removed entirely, but four approaches all
+    /// produced the same silent SSR hang and the work was dropped; the evidence pointed at the
+    /// <c>AuthenticationStateProvider</c> decoration pattern itself rather than at when it is applied.
+    /// </para>
     /// </summary>
     public bool SkipAuthStateDecoration { get; set; } = true;
 

--- a/docs/articles/implementation-guide.md
+++ b/docs/articles/implementation-guide.md
@@ -562,6 +562,8 @@ This setting controls whether the client-side enrichment path is also registered
 
 > **Warning:** Setting `SkipAuthStateDecoration = false` on a Server/SSR app will cause a blank page (silent deadlock from JS interop during prerendering).
 
+> **Unproven:** the `false` path has never been verified against a real standalone WebAssembly app — there is no WASM sample in the repository. If you are the first to use it, expect to validate it yourself, and please report what you find. Automatic hosting-model detection was investigated so this option could disappear entirely, but four separate approaches all produced the same silent SSR hang, and the work was dropped: the evidence pointed at the `AuthenticationStateProvider` decoration pattern itself rather than at when it gets applied.
+
 #### Which setting do I need?
 
 | App type | Setting |


### PR DESCRIPTION
Documentation only — no behaviour change.

`SkipAuthStateDecoration = false` is documented as the setting for standalone Blazor WebAssembly apps, which reads as a supported configuration. It has never actually been verified against a real WASM app — there is no WASM sample in this repository.

Automatic hosting-model detection was on the roadmap so the option could disappear entirely. That work has now been dropped: four separate approaches (try/catch around the JS interop, a cancellation token, reflecting on `IJSRuntime.IsInitialized`, and checking `IHttpContextAccessor.HttpContext`) all produced the same silent SSR hang, and the evidence pointed at the `AuthenticationStateProvider` decoration pattern itself rather than at when it gets applied. With the fix dropped, the limitation is permanent, so it should be stated rather than left implied.

Adds a note to both doc surfaces:

- `ThargaBlazorOptions.SkipAuthStateDecoration` XML docs.
- `docs/articles/implementation-guide.md`, alongside the existing warning about the Server/SSR blank page.

The `true` default is unaffected and remains the recommended setting for Blazor Server, SSR and Hybrid — which is every known consumer.
