### PR TITLE
fix: consent-change audit records the old value for non-member callers

### DIFF
--- a/Tharga.Team.Service.Tests/AuditingTeamServiceMetadataTests.cs
+++ b/Tharga.Team.Service.Tests/AuditingTeamServiceMetadataTests.cs
@@ -144,7 +144,7 @@ public class AuditingTeamServiceMetadataTests
     public async Task SetConsent_RecordsOldAndNewLevelAndRoles()
     {
         var (sut, inner, recorder) = Build();
-        inner.GetTeamsAsync().Returns(Stream<ITeam>(new TestTeam { Key = TeamKey, ConsentAccessLevel = AccessLevel.Viewer }));
+        inner.GetTeamByKeyAsync(TeamKey).Returns(new TestTeam { Key = TeamKey, ConsentAccessLevel = AccessLevel.Viewer });
 
         await sut.SetTeamConsentAsync(TeamKey, ["Developer", "Support"], AccessLevel.Administrator);
 
@@ -159,13 +159,30 @@ public class AuditingTeamServiceMetadataTests
     public async Task SetConsent_WhenCleared_RecordsNoneRatherThanOmittingTheKey()
     {
         var (sut, inner, recorder) = Build();
-        inner.GetTeamsAsync().Returns(Stream<ITeam>(new TestTeam { Key = TeamKey, ConsentAccessLevel = AccessLevel.Administrator }));
+        inner.GetTeamByKeyAsync(TeamKey).Returns(new TestTeam { Key = TeamKey, ConsentAccessLevel = AccessLevel.Administrator });
 
         await sut.SetTeamConsentAsync(TeamKey, [], null);
 
         var metadata = Single(recorder);
         Assert.Equal(nameof(AccessLevel.Administrator), metadata[AuditMetadataKeys.ConsentAccessLevelOld]);
         Assert.Equal("none", metadata[AuditMetadataKeys.ConsentAccessLevelNew]);
+    }
+
+    /// <summary>
+    /// A non-member acting through consent (Administrator-level consent) can change a team's consent, but
+    /// the team isn't among their own teams. The "before" value is now read by exact key, so it's recorded
+    /// for them too — the previous own-teams scan found nothing and omitted it.
+    /// </summary>
+    [Fact]
+    public async Task SetConsent_NonMemberCaller_StillRecordsOldValue()
+    {
+        var (sut, inner, recorder) = Build();
+        inner.GetTeamsAsync().Returns(Stream<ITeam>());  // caller is not a member of this team
+        inner.GetTeamByKeyAsync(TeamKey).Returns(new TestTeam { Key = TeamKey, ConsentAccessLevel = AccessLevel.Viewer });
+
+        await sut.SetTeamConsentAsync(TeamKey, ["Developer"], AccessLevel.Administrator);
+
+        Assert.Equal(nameof(AccessLevel.Viewer), Single(recorder)[AuditMetadataKeys.ConsentAccessLevelOld]);
     }
 
     [Fact]

--- a/Tharga.Team.Service/Audit/AuditingTeamServiceDecorator.cs
+++ b/Tharga.Team.Service/Audit/AuditingTeamServiceDecorator.cs
@@ -41,6 +41,7 @@ public class AuditingTeamServiceDecorator : ITeamService
     public IAsyncEnumerable<ITeam> GetTeamsAsync() => _inner.GetTeamsAsync();
     public IAsyncEnumerable<ITeam<TMember>> GetTeamsAsync<TMember>() where TMember : ITeamMember => _inner.GetTeamsAsync<TMember>();
     public Task<ITeam<TMember>> GetTeamAsync<TMember>(string teamKey) where TMember : ITeamMember => _inner.GetTeamAsync<TMember>(teamKey);
+    public Task<ITeam> GetTeamByKeyAsync(string teamKey) => _inner.GetTeamByKeyAsync(teamKey);
     public Task<ITeamMember> GetTeamMemberAsync(string teamKey, string userKey) => _inner.GetTeamMemberAsync(teamKey, userKey);
     public IAsyncEnumerable<ITeamMember> GetMembersAsync(string teamKey) => _inner.GetMembersAsync(teamKey);
     public IAsyncEnumerable<ITeam> GetConsentedTeamsAsync(string[] userRoles) => _inner.GetConsentedTeamsAsync(userRoles);
@@ -422,24 +423,22 @@ public class AuditingTeamServiceDecorator : ITeamService
     }
 
     /// <summary>
-    /// Team lookup for call sites with no <c>TMember</c> to hand. Scans the caller's own teams, so a
-    /// non-member acting through consent finds nothing — the "before" key is then omitted.
+    /// Exact by-key team read for the "before" value at call sites with no <c>TMember</c> to hand.
+    /// Best-effort: audit detail must never fail the operation it describes, so any error yields null (the
+    /// corresponding metadata key is then omitted). Unlike a scan of the caller's own teams, this also
+    /// finds the team for a non-member acting through consent, so the consent "before" value is recorded
+    /// for them too.
     /// </summary>
     private async Task<ITeam> TryFindTeamAsync(string teamKey)
     {
         try
         {
-            await foreach (var team in _inner.GetTeamsAsync())
-            {
-                if (team.Key == teamKey) return team;
-            }
+            return await _inner.GetTeamByKeyAsync(teamKey);
         }
         catch
         {
-            // Best-effort; fall through.
+            return null;
         }
-
-        return null;
     }
 
     private async Task<ITeamMember> TryGetMemberAsync(string teamKey, string userKey)

--- a/Tharga.Team.Service/AuthorizationTeamServiceDecorator.cs
+++ b/Tharga.Team.Service/AuthorizationTeamServiceDecorator.cs
@@ -52,6 +52,7 @@ public sealed class AuthorizationTeamServiceDecorator : ITeamService
     public IAsyncEnumerable<ITeam> GetTeamsAsync() => _inner.GetTeamsAsync();
     public IAsyncEnumerable<ITeam<TMember>> GetTeamsAsync<TMember>() where TMember : ITeamMember => _inner.GetTeamsAsync<TMember>();
     public Task<ITeam<TMember>> GetTeamAsync<TMember>(string teamKey) where TMember : ITeamMember => _inner.GetTeamAsync<TMember>(teamKey);
+    public Task<ITeam> GetTeamByKeyAsync(string teamKey) => _inner.GetTeamByKeyAsync(teamKey);
     public Task<ITeamMember> GetTeamMemberAsync(string teamKey, string userKey) => _inner.GetTeamMemberAsync(teamKey, userKey);
     public IAsyncEnumerable<ITeamMember> GetMembersAsync(string teamKey) => _inner.GetMembersAsync(teamKey);
     public IAsyncEnumerable<ITeam> GetConsentedTeamsAsync(string[] userRoles) => _inner.GetConsentedTeamsAsync(userRoles);

--- a/Tharga.Team/ITeamService.cs
+++ b/Tharga.Team/ITeamService.cs
@@ -21,6 +21,14 @@ public interface ITeamService
     /// <inheritdoc cref="GetAllTeamsAsync()"/>
     IAsyncEnumerable<ITeam<TMember>> GetAllTeamsAsync<TMember>() where TMember : ITeamMember;
     Task<ITeam<TMember>> GetTeamAsync<TMember>(string teamKey) where TMember : ITeamMember;
+
+    /// <summary>
+    /// A team by key, regardless of the caller's membership — a non-generic exact read for call sites with
+    /// no <c>TMember</c> to hand (e.g. the audit decorator capturing a "before" value for a consent change
+    /// made by a non-member acting through consent). Returns null when the team does not exist.
+    /// </summary>
+    Task<ITeam> GetTeamByKeyAsync(string teamKey);
+
     Task<ITeam> CreateTeamAsync(string name = null);
     Task RenameTeamAsync<TMember>(string teamKey, string name) where TMember : ITeamMember;
     Task DeleteTeamAsync<TMember>(string teamKey) where TMember : ITeamMember;

--- a/Tharga.Team/TeamServiceBase.cs
+++ b/Tharga.Team/TeamServiceBase.cs
@@ -87,6 +87,8 @@ public abstract class TeamServiceBase : ITeamService
         return (ITeam<TMember>)team;
     }
 
+    public Task<ITeam> GetTeamByKeyAsync(string teamKey) => GetTeamAsync(teamKey);
+
     public async Task<ITeam> CreateTeamAsync(string name)
     {
         var user = await RequireCurrentUserAsync();


### PR DESCRIPTION
The consent-change audit entry was missing the previous consent level (`consent.accesslevel.old`) when the caller changing consent is **not a member** of the team.

## Cause
`AuditingTeamServiceDecorator.SetTeamConsentAsync` captured the "before" value by scanning the caller's *own* teams (`GetTeamsAsync()`), because `SetTeamConsentAsync` has no generic `TMember` for an exact read. A non-member acting through **Administrator-level consent** (the one case where a non-member can change consent) isn't in their own teams, so the scan found nothing and the old value was omitted — the "new" value and roles were still recorded.

## Fix
- New `ITeamService.GetTeamByKeyAsync(string teamKey)` — a non-generic, membership-independent exact read (wraps the existing protected team read).
- The consent audit decorator now uses it for the "before" value, so the old consent level is recorded regardless of the caller's membership.

Additive, non-breaking (new interface member with a concrete base implementation and decorator pass-throughs). Reads are ungated, consistent with the existing `GetTeamAsync<TMember>`. Tests: existing consent-metadata tests updated to the exact read, plus a regression test for the non-member case. Full suite green (842).

Patch release (3.4.1).