### PR TITLE
Audit view and API key dialog corrections

### DIFF
--- a/Tharga.Platform.Sample/Program.cs
+++ b/Tharga.Platform.Sample/Program.cs
@@ -105,7 +105,10 @@ builder.AddThargaPlatform(o =>
     // the composition case (Map would throw on an already-mapped role; the toolkit-side grant merges).
     o.ConfigureSystemRoles = roles =>
     {
-        roles.Map("Developer", "system:metrics:read", "mcp:discover", "apikey:manage", "audit:read", SystemUserScopes.Manage);
+        // apikey:system-manage gates the /system-api-keys page. It was missing here and the page still
+        // worked, because IApiKeyManagementService was registered without an enforcing wrapper and its
+        // [RequireScope] was decorative. Now that the registration installs one, the grant has to be real.
+        roles.Map("Developer", "system:metrics:read", "mcp:discover", ApiKeyScopes.Manage, ApiKeyScopes.SystemManage, "audit:read", SystemUserScopes.Manage);
     };
 
     // Logger | MongoDB so the audit entries are both logged and queryable by AuditLogView — the default

--- a/Tharga.Team.Blazor.Tests/AuditPeriodTests.cs
+++ b/Tharga.Team.Blazor.Tests/AuditPeriodTests.cs
@@ -1,0 +1,48 @@
+using Tharga.Team.Blazor.Features.Audit;
+
+namespace Tharga.Team.Blazor.Tests;
+
+/// <summary>
+/// "This week" must mean the whole week. The previous <c>AddDays(-(int)DayOfWeek)</c> counted from
+/// Sunday, so on a Sunday it subtracted nothing and the filter silently showed only today — entries from
+/// yesterday and the day before were missing, while "This month" showed them.
+/// </summary>
+public class AuditPeriodTests
+{
+    [Theory]
+    // Every day of one ISO week resolves to the same Monday.
+    [InlineData("2026-07-20", "2026-07-20")] // Monday
+    [InlineData("2026-07-21", "2026-07-20")] // Tuesday
+    [InlineData("2026-07-22", "2026-07-20")] // Wednesday
+    [InlineData("2026-07-23", "2026-07-20")] // Thursday
+    [InlineData("2026-07-24", "2026-07-20")] // Friday
+    [InlineData("2026-07-25", "2026-07-20")] // Saturday
+    [InlineData("2026-07-26", "2026-07-20")] // Sunday — the day the bug was reported
+    public void StartOfWeek_IsTheMonday(string day, string expected)
+    {
+        Assert.Equal(DateTime.Parse(expected), AuditPeriod.StartOfWeek(DateTime.Parse(day)));
+    }
+
+    [Fact]
+    public void StartOfWeek_OnSunday_LooksBackSixDays()
+    {
+        var sunday = new DateTime(2026, 7, 26);
+
+        Assert.Equal(6, (sunday - AuditPeriod.StartOfWeek(sunday)).TotalDays);
+    }
+
+    [Fact]
+    public void StartOfWeek_DiscardsTheTimeOfDay()
+    {
+        var sundayAfternoon = new DateTime(2026, 7, 26, 14, 30, 0);
+
+        Assert.Equal(new DateTime(2026, 7, 20), AuditPeriod.StartOfWeek(sundayAfternoon));
+    }
+
+    [Fact]
+    public void StartOfWeek_CrossesAMonthBoundary()
+    {
+        // Wednesday 1 July 2026 — the week starts in June.
+        Assert.Equal(new DateTime(2026, 6, 29), AuditPeriod.StartOfWeek(new DateTime(2026, 7, 1)));
+    }
+}

--- a/Tharga.Team.Blazor.Tests/AuditPeriodTests.cs
+++ b/Tharga.Team.Blazor.Tests/AuditPeriodTests.cs
@@ -3,46 +3,57 @@ using Tharga.Team.Blazor.Features.Audit;
 namespace Tharga.Team.Blazor.Tests;
 
 /// <summary>
-/// "This week" must mean the whole week. The previous <c>AddDays(-(int)DayOfWeek)</c> counted from
-/// Sunday, so on a Sunday it subtracted nothing and the filter silently showed only today — entries from
-/// yesterday and the day before were missing, while "This month" showed them.
+/// The period filter reads back a fixed number of days from now. It replaced calendar "This week" /
+/// "This month" options, whose week arithmetic counted from Sunday — so on a Sunday "This week"
+/// subtracted nothing and silently showed only today, while "This month" showed the missing entries.
+/// A rolling window has no week-start to get wrong.
 /// </summary>
 public class AuditPeriodTests
 {
+    private static readonly DateTime UtcNow = new(2026, 7, 26, 9, 30, 0, DateTimeKind.Utc);
+    private static readonly DateTime LocalToday = new(2026, 7, 26, 0, 0, 0, DateTimeKind.Local);
+
     [Theory]
-    // Every day of one ISO week resolves to the same Monday.
-    [InlineData("2026-07-20", "2026-07-20")] // Monday
-    [InlineData("2026-07-21", "2026-07-20")] // Tuesday
-    [InlineData("2026-07-22", "2026-07-20")] // Wednesday
-    [InlineData("2026-07-23", "2026-07-20")] // Thursday
-    [InlineData("2026-07-24", "2026-07-20")] // Friday
-    [InlineData("2026-07-25", "2026-07-20")] // Saturday
-    [InlineData("2026-07-26", "2026-07-20")] // Sunday — the day the bug was reported
-    public void StartOfWeek_IsTheMonday(string day, string expected)
+    [InlineData(AuditPeriod.SevenDays, 7)]
+    [InlineData(AuditPeriod.ThirtyDays, 30)]
+    [InlineData(AuditPeriod.NinetyDays, 90)]
+    public void RollingWindow_CountsBackFromNow(string period, int days)
     {
-        Assert.Equal(DateTime.Parse(expected), AuditPeriod.StartOfWeek(DateTime.Parse(day)));
+        var from = AuditPeriod.ResolveFrom(period, UtcNow, LocalToday);
+
+        Assert.Equal(UtcNow.AddDays(-days), from);
+    }
+
+    [Theory]
+    [InlineData("2026-07-20")] // Monday
+    [InlineData("2026-07-24")] // Friday
+    [InlineData("2026-07-26")] // Sunday — the day the calendar-week bug surfaced
+    public void RollingWindow_IsTheSameLengthOnEveryWeekday(string today)
+    {
+        var now = DateTime.SpecifyKind(DateTime.Parse(today).AddHours(9), DateTimeKind.Utc);
+
+        var from = AuditPeriod.ResolveFrom(AuditPeriod.SevenDays, now, now.Date);
+
+        Assert.Equal(7, (now - from!.Value).TotalDays);
     }
 
     [Fact]
-    public void StartOfWeek_OnSunday_LooksBackSixDays()
+    public void Today_IsTheReadersCalendarDay()
     {
-        var sunday = new DateTime(2026, 7, 26);
+        var from = AuditPeriod.ResolveFrom(AuditPeriod.Today, UtcNow, LocalToday);
 
-        Assert.Equal(6, (sunday - AuditPeriod.StartOfWeek(sunday)).TotalDays);
+        Assert.Equal(LocalToday.ToUniversalTime(), from);
     }
 
     [Fact]
-    public void StartOfWeek_DiscardsTheTimeOfDay()
+    public void All_HasNoLowerBound()
     {
-        var sundayAfternoon = new DateTime(2026, 7, 26, 14, 30, 0);
-
-        Assert.Equal(new DateTime(2026, 7, 20), AuditPeriod.StartOfWeek(sundayAfternoon));
+        Assert.Null(AuditPeriod.ResolveFrom(AuditPeriod.All, UtcNow, LocalToday));
     }
 
     [Fact]
-    public void StartOfWeek_CrossesAMonthBoundary()
+    public void AnUnknownPeriod_HasNoLowerBound()
     {
-        // Wednesday 1 July 2026 — the week starts in June.
-        Assert.Equal(new DateTime(2026, 6, 29), AuditPeriod.StartOfWeek(new DateTime(2026, 7, 1)));
+        Assert.Null(AuditPeriod.ResolveFrom("whenever", UtcNow, LocalToday));
     }
 }

--- a/Tharga.Team.Blazor.Tests/AuditRetentionTextTests.cs
+++ b/Tharga.Team.Blazor.Tests/AuditRetentionTextTests.cs
@@ -1,0 +1,30 @@
+using Tharga.Team.Blazor.Features.Audit;
+
+namespace Tharga.Team.Blazor.Tests;
+
+/// <summary>
+/// The audit view states how long entries are kept, so a short history reads as retention rather than as
+/// nothing having happened. Unlimited retention has to say so explicitly — silence would leave the reader
+/// to guess which of the two they are looking at.
+/// </summary>
+public class AuditRetentionTextTests
+{
+    [Theory]
+    [InlineData(90)]
+    [InlineData(30)]
+    [InlineData(1)]
+    public void WithRetention_NamesTheNumberOfDays(int days)
+    {
+        Assert.Equal($"Entries are kept for {days} days, then deleted automatically.", AuditRetentionText.Describe(days));
+    }
+
+    [Theory]
+    // null, 0 and negatives all mean "no TTL index" to AuditOptions — they must read the same way.
+    [InlineData(null)]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void WithoutRetention_SaysEntriesAreKept(int? days)
+    {
+        Assert.Equal("Entries are kept indefinitely.", AuditRetentionText.Describe(days));
+    }
+}

--- a/Tharga.Team.Blazor/Features/Api/ApiKeyRevealDialog.razor
+++ b/Tharga.Team.Blazor/Features/Api/ApiKeyRevealDialog.razor
@@ -4,14 +4,25 @@
 @inject NotificationService NotificationService
 
 @*
-    Shown once, immediately after an API key is created or regenerated. This is the only time the raw
-    key value is available — it is not stored and cannot be retrieved again (and when auto-lock is on
-    it is locked the moment it's created). Give the user a clear, copyable view with a warning.
+    Shown immediately after an API key is created or regenerated. Whether this is the *only* chance to
+    read the value depends on the host's ApiKeyOptions.AutoLockKeys: locking clears the stored value
+    (ApiKeyRepository.LockKeyAsync sets ApiKey to null), so with auto-lock on the key really is
+    unrecoverable — but that is off by default, and an unlocked key stays readable from the key list.
+    Claiming otherwise would misdescribe the host's security posture and prompt needless regeneration.
 *@
 <RadzenStack Gap="1rem">
-    <RadzenAlert AlertStyle="AlertStyle.Warning" ShowIcon="true" Variant="Variant.Flat" AllowClose="false">
-        Copy this key now. For security it is <b>shown only once</b> and is <b>not stored</b> — you will not be able to retrieve it again. If you lose it, regenerate the key to get a new one.
-    </RadzenAlert>
+    @if (RemainsRetrievable)
+    {
+        <RadzenAlert AlertStyle="AlertStyle.Info" ShowIcon="true" Variant="Variant.Flat" AllowClose="false">
+            Copy this key now, or read it later from the key list — it stays <b>stored</b> until the key is locked. Lock it once you have copied it, to clear the stored value.
+        </RadzenAlert>
+    }
+    else
+    {
+        <RadzenAlert AlertStyle="AlertStyle.Warning" ShowIcon="true" Variant="Variant.Flat" AllowClose="false">
+            Copy this key now. For security it is <b>shown only once</b> and is <b>not stored</b> — you will not be able to retrieve it again. If you lose it, regenerate the key to get a new one.
+        </RadzenAlert>
+    }
 
     <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem">
         <RadzenTextBox Value="@ApiKey" ReadOnly="true" Style="width: 100%; font-family: monospace;" />
@@ -24,8 +35,15 @@
 </RadzenStack>
 
 @code {
-    /// <summary>The raw API key value to reveal (shown once).</summary>
+    /// <summary>The raw API key value to reveal.</summary>
     [Parameter] public string ApiKey { get; set; }
+
+    /// <summary>
+    /// Whether the value remains readable after this dialog closes — true unless the key is locked on
+    /// creation (<see cref="ApiKeyOptions.AutoLockKeys"/>), which clears the stored value. Drives the
+    /// warning, so that it describes what the host is actually configured to do.
+    /// </summary>
+    [Parameter] public bool RemainsRetrievable { get; set; }
 
     private async Task CopyAsync()
     {

--- a/Tharga.Team.Blazor/Features/Api/ApiKeyView.razor
+++ b/Tharga.Team.Blazor/Features/Api/ApiKeyView.razor
@@ -397,7 +397,11 @@ else
         if (key == null || string.IsNullOrEmpty(key.ApiKey)) return;
         await DialogService.OpenAsync<ApiKeyRevealDialog>(
             $"API key — {key.Name}",
-            new Dictionary<string, object> { [nameof(ApiKeyRevealDialog.ApiKey)] = key.ApiKey },
+            new Dictionary<string, object>
+            {
+                [nameof(ApiKeyRevealDialog.ApiKey)] = key.ApiKey,
+                [nameof(ApiKeyRevealDialog.RemainsRetrievable)] = !_options.AutoLockKeys
+            },
             new DialogOptions { Width = "640px", CloseDialogOnOverlayClick = false });
     }
 

--- a/Tharga.Team.Blazor/Features/Api/SystemApiKeyView.razor
+++ b/Tharga.Team.Blazor/Features/Api/SystemApiKeyView.razor
@@ -1,7 +1,9 @@
 ﻿@using Microsoft.Extensions.DependencyInjection
+@using Microsoft.Extensions.Options
 @using Microsoft.JSInterop
 @using Tharga.Team
 @using Tharga.Team.Blazor.Framework
+@inject IOptions<ApiKeyOptions> ApiKeyOptionsAccessor
 @inject IServiceProvider ServiceProvider
 @inject IJSRuntime Js
 @inject DialogService DialogService
@@ -227,7 +229,11 @@
         if (key == null || string.IsNullOrEmpty(key.ApiKey)) return;
         await DialogService.OpenAsync<ApiKeyRevealDialog>(
             $"System API key — {key.Name}",
-            new Dictionary<string, object> { [nameof(ApiKeyRevealDialog.ApiKey)] = key.ApiKey },
+            new Dictionary<string, object>
+            {
+                [nameof(ApiKeyRevealDialog.ApiKey)] = key.ApiKey,
+                [nameof(ApiKeyRevealDialog.RemainsRetrievable)] = !ApiKeyOptionsAccessor.Value.AutoLockKeys
+            },
             new DialogOptions { Width = "640px", CloseDialogOnOverlayClick = false });
     }
 

--- a/Tharga.Team.Blazor/Features/Audit/AuditLogView.razor
+++ b/Tharga.Team.Blazor/Features/Audit/AuditLogView.razor
@@ -62,8 +62,12 @@ else
                             </Items>
                         </RadzenSelectBar>
                     </RadzenStack>
+                    @* Feature and Action are the required scope split on its colon — apikey:manage is
+                       feature "apikey", action "manage". Labelled as such so the connection to the Scope
+                       column is visible, and kept as two filters so "everything that changed anything"
+                       (action: manage, across features) stays one click. *@
                     <RadzenStack Orientation="Orientation.Vertical" Gap="0" Visible="@(_features.Any() && PinnedFilter?.Feature == null)">
-                        <RadzenLabel Text="Feature" />
+                        <RadzenLabel Text="Scope feature" />
                         <RadzenSelectBar @bind-Value="_filterFeatures" TValue="IEnumerable<string>" Multiple="true"
                                          Change="@OnFilterChanged" Size="ButtonSize.Small">
                             <Items>
@@ -78,7 +82,7 @@ else
                        rather than select bars — a bar of every action wraps to several rows and pushes
                        the grid off screen. *@
                     <RadzenStack Orientation="Orientation.Vertical" Gap="0" Visible="@(_actions.Any() && PinnedFilter?.Action == null)">
-                        <RadzenLabel Text="Action" />
+                        <RadzenLabel Text="Scope action" />
                         <RadzenDropDown @bind-Value="_filterActions" TValue="IEnumerable<string>" Data="@_actions"
                                         Multiple="true" AllowClear="true" AllowFiltering="true"
                                         Placeholder="All" Change="@(_ => OnFilterChanged())"
@@ -193,7 +197,9 @@ else
                     </Template>
                 </RadzenDataGrid>
 
-                <RadzenText TextStyle="TextStyle.Caption" class="rz-mt-1">@_totalCount total entries</RadzenText>
+                @* Sits with the count, so an unexpectedly short history reads as retention rather than as
+                   nothing having happened. *@
+                <RadzenText TextStyle="TextStyle.Caption" class="rz-mt-1">@_totalCount total entries. @RetentionText</RadzenText>
             </RadzenTabsItem>
 
             <RadzenTabsItem Text="Usage">

--- a/Tharga.Team.Blazor/Features/Audit/AuditLogView.razor
+++ b/Tharga.Team.Blazor/Features/Audit/AuditLogView.razor
@@ -1,4 +1,4 @@
-@using Tharga.Team.Service.Audit
+﻿@using Tharga.Team.Service.Audit
 
 @if (!_hasAccess)
 {
@@ -25,22 +25,9 @@ else
     <RadzenTabs Change="@OnTabChange">
         <Tabs>
             <RadzenTabsItem Text="Log">
-                @if (PinnedFilter != null)
-                {
-                    <RadzenAlert AlertStyle="AlertStyle.Info" ShowIcon="true" Variant="Variant.Flat" AllowClose="false" class="rz-mb-3">
-                        <RadzenText TextStyle="TextStyle.Body2">
-                            Scoped view —
-                            @if (PinnedFilter.CallerKeyId != null) { <span>API key <code>@PinnedFilter.CallerKeyId</code> </span> }
-                            @if (PinnedFilter.CallerType != null) { <span>caller type <code>@PinnedFilter.CallerType</code> </span> }
-                            @if (PinnedFilter.TeamKey != null) { <span>team <code>@PinnedFilter.TeamKey</code> </span> }
-                            @if (PinnedFilter.CallerIdentity != null) { <span>caller <code>@PinnedFilter.CallerIdentity</code> </span> }
-                            @if (PinnedFilter.Feature != null) { <span>feature <code>@PinnedFilter.Feature</code> </span> }
-                            @if (PinnedFilter.Action != null) { <span>action <code>@PinnedFilter.Action</code> </span> }
-                        </RadzenText>
-                    </RadzenAlert>
-                }
-
-                @* Top-bar filters — all RadzenSelectBar multi-select *@
+                @* Pinned dimensions are hidden rather than announced: the host chose the scope and says so
+                   in its own words, and a banner naming raw keys is noise on a page built for one team. *@
+                @* Top-bar filters *@
                 <RadzenStack Orientation="Orientation.Horizontal" Gap="0.5rem" AlignItems="AlignItems.End" class="rz-mb-4 rz-mt-2" Wrap="FlexWrap.Wrap">
                     <RadzenStack Orientation="Orientation.Vertical" Gap="0">
                         <RadzenLabel Text="Period" />
@@ -53,11 +40,10 @@ else
                             </Items>
                         </RadzenSelectBar>
                     </RadzenStack>
-                    <RadzenStack Orientation="Orientation.Vertical" Gap="0" Visible="@(_teams.Any())">
+                    <RadzenStack Orientation="Orientation.Vertical" Gap="0" Visible="@(_teams.Any() && PinnedFilter?.TeamKey == null)">
                         <RadzenLabel Text="Team" />
                         <RadzenSelectBar @bind-Value="_filterTeams" TValue="IEnumerable<string>" Multiple="true"
-                                         Change="@OnFilterChanged" Size="ButtonSize.Small"
-                                         Disabled="@(PinnedFilter?.TeamKey != null)">
+                                         Change="@OnFilterChanged" Size="ButtonSize.Small">
                             <Items>
                                 @foreach (var team in _teams)
                                 {
@@ -78,11 +64,10 @@ else
                             </Items>
                         </RadzenSelectBar>
                     </RadzenStack>
-                    <RadzenStack Orientation="Orientation.Vertical" Gap="0" Visible="@(_features.Any())">
+                    <RadzenStack Orientation="Orientation.Vertical" Gap="0" Visible="@(_features.Any() && PinnedFilter?.Feature == null)">
                         <RadzenLabel Text="Feature" />
                         <RadzenSelectBar @bind-Value="_filterFeatures" TValue="IEnumerable<string>" Multiple="true"
-                                         Change="@OnFilterChanged" Size="ButtonSize.Small"
-                                         Disabled="@(PinnedFilter?.Feature != null)">
+                                         Change="@OnFilterChanged" Size="ButtonSize.Small">
                             <Items>
                                 @foreach (var f in _features)
                                 {
@@ -91,33 +76,25 @@ else
                             </Items>
                         </RadzenSelectBar>
                     </RadzenStack>
-                    <RadzenStack Orientation="Orientation.Vertical" Gap="0" Visible="@(_actions.Any())">
+                    @* Action and Event carry many values and grow with the app, so they are drop-downs
+                       rather than select bars — a bar of every action wraps to several rows and pushes
+                       the grid off screen. *@
+                    <RadzenStack Orientation="Orientation.Vertical" Gap="0" Visible="@(_actions.Any() && PinnedFilter?.Action == null)">
                         <RadzenLabel Text="Action" />
-                        <RadzenSelectBar @bind-Value="_filterActions" TValue="IEnumerable<string>" Multiple="true"
-                                         Change="@OnFilterChanged" Size="ButtonSize.Small"
-                                         Disabled="@(PinnedFilter?.Action != null)">
-                            <Items>
-                                @foreach (var a in _actions)
-                                {
-                                    <RadzenSelectBarItem Text="@a" Value="@a" />
-                                }
-                            </Items>
-                        </RadzenSelectBar>
+                        <RadzenDropDown @bind-Value="_filterActions" TValue="IEnumerable<string>" Data="@_actions"
+                                        Multiple="true" AllowClear="true" AllowFiltering="true"
+                                        Placeholder="All" Change="@(_ => OnFilterChanged())"
+                                        Style="width: 200px;" />
                     </RadzenStack>
                     <RadzenStack Orientation="Orientation.Vertical" Gap="0">
                         <RadzenLabel Text="Event" />
-                        <RadzenSelectBar @bind-Value="_filterEventTypes" TValue="IEnumerable<AuditEventType>" Multiple="true"
-                                         Change="@OnFilterChanged" Size="ButtonSize.Small">
-                            <Items>
-                                @foreach (var et in EventTypeOptions)
-                                {
-                                    <RadzenSelectBarItem Text="@et.ToString()" Value="@et" />
-                                }
-                            </Items>
-                        </RadzenSelectBar>
+                        <RadzenDropDown @bind-Value="_filterEventTypes" TValue="IEnumerable<AuditEventType>" Data="@EventTypeOptions"
+                                        Multiple="true" AllowClear="true"
+                                        Placeholder="All" Change="@(_ => OnFilterChanged())"
+                                        Style="width: 200px;" />
                     </RadzenStack>
                     <RadzenStack Orientation="Orientation.Vertical" Gap="0">
-                        <RadzenLabel Text="OK" />
+                        <RadzenLabel Text="Result" />
                         <RadzenSelectBar @bind-Value="_filterSuccess" TValue="IEnumerable<bool>" Multiple="true"
                                          Change="@OnFilterChanged" Size="ButtonSize.Small">
                             <Items>
@@ -174,7 +151,7 @@ else
                         <RadzenDataGridColumn Title="Event" Width="110px" Filterable="false" Sortable="false">
                             <Template>@context.EventType</Template>
                         </RadzenDataGridColumn>
-                        <RadzenDataGridColumn Title="OK" Width="160px" Filterable="false" Sortable="false">
+                        <RadzenDataGridColumn Title="Result" Width="160px" Filterable="false" Sortable="false">
                             <Template>
                                 @if (context.Success)
                                 {

--- a/Tharga.Team.Blazor/Features/Audit/AuditLogView.razor
+++ b/Tharga.Team.Blazor/Features/Audit/AuditLogView.razor
@@ -42,17 +42,14 @@ else
                     </RadzenStack>
                     <RadzenStack Orientation="Orientation.Vertical" Gap="0" Visible="@(_teams.Any() && PinnedFilter?.TeamKey == null)">
                         <RadzenLabel Text="Team" />
-                        <RadzenSelectBar @bind-Value="_filterTeams" TValue="IEnumerable<string>" Multiple="true"
-                                         Change="@OnFilterChanged" Size="ButtonSize.Small">
-                            <Items>
-                                @foreach (var team in _teams)
-                                {
-                                    <RadzenSelectBarItem Text="@team.Name" Value="@team.Key" />
-                                }
-                            </Items>
-                        </RadzenSelectBar>
+                        <RadzenDropDown @bind-Value="_filterTeams" TValue="IEnumerable<string>" Data="@_teams"
+                                        TextProperty="@nameof(TeamInfo.Name)" ValueProperty="@nameof(TeamInfo.Key)"
+                                        Multiple="true" AllowClear="true" AllowFiltering="true"
+                                        Placeholder="All" Change="@(_ => OnFilterChanged())"
+                                        Style="width: 200px;" />
                     </RadzenStack>
-                    <RadzenStack Orientation="Orientation.Vertical" Gap="0" Visible="@(_sources.Any())">
+                    @* A single source tells the reader nothing they can act on — one option is not a filter. *@
+                    <RadzenStack Orientation="Orientation.Vertical" Gap="0" Visible="@(_sources.Count > 1)">
                         <RadzenLabel Text="Source" />
                         <RadzenSelectBar @bind-Value="_filterSources" TValue="IEnumerable<string>" Multiple="true"
                                          Change="@OnFilterChanged" Size="ButtonSize.Small">

--- a/Tharga.Team.Blazor/Features/Audit/AuditLogView.razor
+++ b/Tharga.Team.Blazor/Features/Audit/AuditLogView.razor
@@ -33,10 +33,11 @@ else
                         <RadzenLabel Text="Period" />
                         <RadzenSelectBar @bind-Value="_datePeriod" TValue="string" Change="@OnFilterChanged" Size="ButtonSize.Small">
                             <Items>
-                                <RadzenSelectBarItem Text="Today" Value="@("today")" />
-                                <RadzenSelectBarItem Text="This Week" Value="@("week")" />
-                                <RadzenSelectBarItem Text="This Month" Value="@("month")" />
-                                <RadzenSelectBarItem Text="All" Value="@("all")" />
+                                <RadzenSelectBarItem Text="Today" Value="@AuditPeriod.Today" />
+                                <RadzenSelectBarItem Text="7 days" Value="@AuditPeriod.SevenDays" />
+                                <RadzenSelectBarItem Text="30 days" Value="@AuditPeriod.ThirtyDays" />
+                                <RadzenSelectBarItem Text="90 days" Value="@AuditPeriod.NinetyDays" />
+                                <RadzenSelectBarItem Text="All" Value="@AuditPeriod.All" />
                             </Items>
                         </RadzenSelectBar>
                     </RadzenStack>

--- a/Tharga.Team.Blazor/Features/Audit/AuditLogView.razor.cs
+++ b/Tharga.Team.Blazor/Features/Audit/AuditLogView.razor.cs
@@ -20,11 +20,19 @@ public partial class AuditLogView : ComponentBase
     [Parameter] public AuditCallerType? RestrictCallerType { get; set; }
 
     /// <summary>
-    /// Optional fixed filter dimensions. When set, the matching top-bar controls render
-    /// disabled with the pinned values selected, and the underlying query is forced to
-    /// the pinned values regardless of in-component state.
+    /// Optional fixed filter dimensions. When set, the matching top-bar controls are hidden — the caller
+    /// cannot change them — and the underlying query is forced to the pinned values regardless of
+    /// in-component state.
     /// </summary>
     [Parameter] public AuditPinnedFilter PinnedFilter { get; set; }
+
+    /// <summary>
+    /// How long entries are kept, described for the reader. Null when retention is unlimited, so that an
+    /// empty result reads as "nothing happened" rather than "it aged out".
+    /// </summary>
+    private string RetentionText
+        => AuditRetentionText.Describe(
+            ServiceProvider.GetService<Microsoft.Extensions.Options.IOptions<AuditOptions>>()?.Value.RetentionDays);
 
     private const int ChartQueryLimit = 5000;
 

--- a/Tharga.Team.Blazor/Features/Audit/AuditLogView.razor.cs
+++ b/Tharga.Team.Blazor/Features/Audit/AuditLogView.razor.cs
@@ -43,7 +43,7 @@ public partial class AuditLogView : ComponentBase
     internal Dictionary<string, string> _callerNameCache = new(StringComparer.OrdinalIgnoreCase);
 
     // Top-bar filters
-    private string _datePeriod = "today";
+    private string _datePeriod = AuditPeriod.Today;
     private IEnumerable<string> _filterTeams = Enumerable.Empty<string>();
     private IEnumerable<string> _filterSources = Enumerable.Empty<string>();
     private IEnumerable<string> _filterFeatures = Enumerable.Empty<string>();
@@ -283,14 +283,7 @@ public partial class AuditLogView : ComponentBase
 
     private (DateTime? from, DateTime? to) GetDateRange()
     {
-        var now = DateTime.UtcNow;
-        return _datePeriod switch
-        {
-            "today" => (DateTime.Today.ToUniversalTime(), null),
-            "week" => (AuditPeriod.StartOfWeek(DateTime.Today).ToUniversalTime(), null),
-            "month" => (new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc), null),
-            _ => (null, null)
-        };
+        return (AuditPeriod.ResolveFrom(_datePeriod, DateTime.UtcNow, DateTime.Today), null);
     }
 
 

--- a/Tharga.Team.Blazor/Features/Audit/AuditLogView.razor.cs
+++ b/Tharga.Team.Blazor/Features/Audit/AuditLogView.razor.cs
@@ -287,11 +287,12 @@ public partial class AuditLogView : ComponentBase
         return _datePeriod switch
         {
             "today" => (DateTime.Today.ToUniversalTime(), null),
-            "week" => (DateTime.Today.AddDays(-(int)DateTime.Today.DayOfWeek).ToUniversalTime(), null),
+            "week" => (AuditPeriod.StartOfWeek(DateTime.Today).ToUniversalTime(), null),
             "month" => (new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc), null),
             _ => (null, null)
         };
     }
+
 
     private async Task LoadChartDataAsync()
     {

--- a/Tharga.Team.Blazor/Features/Audit/AuditPeriod.cs
+++ b/Tharga.Team.Blazor/Features/Audit/AuditPeriod.cs
@@ -1,22 +1,41 @@
 namespace Tharga.Team.Blazor.Features.Audit;
 
 /// <summary>
-/// Date arithmetic for the audit log's period filter.
+/// The audit log's period filter: how far back the log is read.
 /// </summary>
 /// <remarks>
+/// Rolling windows counted back from now, rather than calendar weeks and months. "This week" invited two
+/// questions the reader should not have to answer — where the week starts, and whether a Sunday belongs
+/// to the week ending or beginning — and got the first one wrong for six days out of seven. "7 days"
+/// means the last seven days from this moment, on every day of the week and in every locale.
+/// <para>
 /// Pure and static so it is unit-testable — this project has no bUnit, so a calculation left inside the
 /// component is unreachable from tests. Mirrors <c>TeamActionGate</c> and <c>TeamVisibility</c>.
+/// </para>
 /// </remarks>
 internal static class AuditPeriod
 {
+    public const string Today = "today";
+    public const string SevenDays = "7d";
+    public const string ThirtyDays = "30d";
+    public const string NinetyDays = "90d";
+    public const string All = "all";
+
     /// <summary>
-    /// The Monday that starts <paramref name="day"/>'s week (ISO-8601).
+    /// The earliest timestamp the filter admits, or null for no lower bound.
     /// </summary>
-    /// <remarks>
-    /// Not <c>AddDays(-(int)DayOfWeek)</c>: that counts from Sunday, because
-    /// <see cref="System.DayOfWeek.Sunday"/> is 0. On a Sunday it subtracts nothing, so "This week"
-    /// silently collapses to "Today" and hides the six days the reader is asking for.
-    /// </remarks>
-    public static DateTime StartOfWeek(DateTime day)
-        => day.Date.AddDays(-(((int)day.DayOfWeek + 6) % 7));
+    /// <param name="period">One of the period constants on this type.</param>
+    /// <param name="utcNow">Now, in UTC — the anchor the rolling windows count back from.</param>
+    /// <param name="localToday">
+    /// Local midnight, for <see cref="Today"/> only. "Today" is the reader's calendar day, so it is the one
+    /// option that must be resolved in their time zone rather than UTC.
+    /// </param>
+    public static DateTime? ResolveFrom(string period, DateTime utcNow, DateTime localToday) => period switch
+    {
+        Today => localToday.ToUniversalTime(),
+        SevenDays => utcNow.AddDays(-7),
+        ThirtyDays => utcNow.AddDays(-30),
+        NinetyDays => utcNow.AddDays(-90),
+        _ => null
+    };
 }

--- a/Tharga.Team.Blazor/Features/Audit/AuditPeriod.cs
+++ b/Tharga.Team.Blazor/Features/Audit/AuditPeriod.cs
@@ -1,0 +1,22 @@
+namespace Tharga.Team.Blazor.Features.Audit;
+
+/// <summary>
+/// Date arithmetic for the audit log's period filter.
+/// </summary>
+/// <remarks>
+/// Pure and static so it is unit-testable — this project has no bUnit, so a calculation left inside the
+/// component is unreachable from tests. Mirrors <c>TeamActionGate</c> and <c>TeamVisibility</c>.
+/// </remarks>
+internal static class AuditPeriod
+{
+    /// <summary>
+    /// The Monday that starts <paramref name="day"/>'s week (ISO-8601).
+    /// </summary>
+    /// <remarks>
+    /// Not <c>AddDays(-(int)DayOfWeek)</c>: that counts from Sunday, because
+    /// <see cref="System.DayOfWeek.Sunday"/> is 0. On a Sunday it subtracts nothing, so "This week"
+    /// silently collapses to "Today" and hides the six days the reader is asking for.
+    /// </remarks>
+    public static DateTime StartOfWeek(DateTime day)
+        => day.Date.AddDays(-(((int)day.DayOfWeek + 6) % 7));
+}

--- a/Tharga.Team.Blazor/Features/Audit/AuditPinnedFilter.cs
+++ b/Tharga.Team.Blazor/Features/Audit/AuditPinnedFilter.cs
@@ -4,10 +4,15 @@ namespace Tharga.Team.Blazor.Features.Audit;
 
 /// <summary>
 /// Locks one or more <see cref="AuditLogView"/> filter dimensions to a fixed value.
-/// Pinned dimensions are visible in the UI but disabled, and they are forced into the
-/// underlying <see cref="AuditQuery"/> regardless of any in-component filter state.
+/// Pinned dimensions are <b>hidden</b> from the filter bar — the caller cannot change them, so showing
+/// a disabled control is only clutter — and are forced into the underlying <see cref="AuditQuery"/>
+/// regardless of any in-component filter state.
 /// Use to scope the audit log to a single API key, team, caller, etc.
 /// </summary>
+/// <remarks>
+/// The component does not announce the scope it is showing. The host chose it and can describe it in its
+/// own words, with names rather than the keys pinned here.
+/// </remarks>
 public sealed record AuditPinnedFilter
 {
     /// <summary>Pin to a specific API key Guid string.</summary>

--- a/Tharga.Team.Blazor/Features/Audit/AuditRetentionText.cs
+++ b/Tharga.Team.Blazor/Features/Audit/AuditRetentionText.cs
@@ -1,0 +1,17 @@
+namespace Tharga.Team.Blazor.Features.Audit;
+
+/// <summary>
+/// How the audit log describes its own retention to the reader.
+/// </summary>
+/// <remarks>
+/// Pure and static so it is unit-testable — this project has no bUnit. The nil case matters: null, zero
+/// and negative all mean "no TTL index" to <c>AuditOptions.RetentionDays</c>, so all three must produce
+/// the same sentence rather than "kept for 0 days".
+/// </remarks>
+internal static class AuditRetentionText
+{
+    public static string Describe(int? retentionDays)
+        => retentionDays is > 0
+            ? $"Entries are kept for {retentionDays} days, then deleted automatically."
+            : "Entries are kept indefinitely.";
+}


### PR DESCRIPTION
Corrections to the audit log view and the API key reveal dialog, all found by reading the running app.

> **Stacked on #143.** Based on `feature/team-bound-service-authorization`; retarget to `master` once that merges. Only the last five commits belong to this PR.

## The API key dialog was telling users something false

> "Copy this key now. For security it is **shown only once** and is **not stored** — you will not be able to retrieve it again."

That is true only when the key is locked. `ApiKeyRepository.LockKeyAsync` clears the stored value, and `ApiKeyOptions.AutoLockKeys` locks on creation — but it defaults to **false**. In the default configuration the value stays in the database and the key list's own context menu offers "Show value" and "Copy" on any row.

The dialog now describes what the host is actually configured to do. When the key remains readable it says so, and points at the action that makes it unrecoverable:

> "Copy this key now, or read it later from the key list — it stays **stored** until the key is locked. Lock it once you have copied it, to clear the stored value."

Styled Info rather than Warning, because in that configuration nothing alarming has happened. Both `ApiKeyView` and `SystemApiKeyView` pass the flag; system keys go through the same `AutoLockKeys` branch.

## "This week" showed only today

```csharp
"week" => DateTime.Today.AddDays(-(int)DateTime.Today.DayOfWeek)
```

`DayOfWeek.Sunday` is **0**, so this counted weeks from Sunday. On a Sunday it subtracted nothing and "This week" silently collapsed to "Today" — entries from one and two days earlier vanished, while "This month" showed them.

Rather than fix the week arithmetic, the calendar options are replaced by **rolling day windows**: Today · 7 days · 30 days · 90 days · All. A rolling window has no week start to get wrong, so the bug cannot return in another guise.

One deliberate asymmetry: the windows count back from `UtcNow`, but **Today** resolves from *local* midnight — Today is the reader's calendar day, the others are durations. Documented on the parameter so it is not "tidied" into consistency later.

## Audit filter bar

- **The "Scoped view — team `t-4f9a…`" banner is gone.** The host chose the scope and can describe it in its own words, with names rather than raw keys.
- **Pinned dimensions are hidden rather than disabled.** A control the caller cannot change is clutter.
- **Action and Event are drop-downs**; a select bar of every action wrapped to several rows and pushed the grid off screen. Team is a drop-down too. Source hides when there is only one value — one option is not a filter.
- **Feature and Action are now labelled "Scope feature" and "Scope action".** They are the required scope split on its colon (`apikey:manage` → feature `apikey`, action `manage`), which the labels never said. Kept as two filters rather than merged into one "Scope": the grid already has a Scope column, and the split is what makes "everything that changed anything" one click.
- **"OK" is now "Result"**, on both the column and the filter.
- **Retention is stated** beside the entry count — "Entries are kept for 90 days, then deleted automatically" — so a short history reads as retention rather than as nothing having happened. Null, `0` and negative all mean *keep forever* to `AuditOptions`, so all three render "kept indefinitely" rather than "kept for 0 days".

## Also here

The sample grants `apikey:system-manage` to its Developer role. That belongs with #143 — the scope was never granted and `/system-api-keys` worked only because nothing enforced it — but it shares a commit with the audit-view work, and splitting the hunk was not worth the surgery.

## Verification

Build clean; 984 tests pass. New pure classes carry the logic that was previously unreachable from tests: `AuditPeriod` (10 tests, including every weekday) and `AuditRetentionText` (6, including the null/zero/negative case). The dialog and filter-bar markup have no test coverage — this repo has no bUnit.
