### PR TITLE
Move the release version line to 3.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,8 @@ on:
     branches: [master]
 
 env:
-  MAJOR_MINOR: '3.5'
+  # Bump by hand when a release breaks compatibility or adds public API; only the patch is automatic.
+  MAJOR_MINOR: '3.6'
 
 permissions:
   contents: write


### PR DESCRIPTION
Moves the release version line from `3.5` to `3.6`, so the next release is **3.6.0**.

## Why

`MAJOR_MINOR` is the only manual part of versioning — the patch number is computed from the latest tag, so the constant is what decides whether a release reads as a patch or a minor. Nothing in the pipeline notices when a release breaks compatibility.

It went unnoticed once already: **3.5.3** shipped the scope-claim provenance split, which requires consumers reading `TeamClaimTypes.Scope` for a system grant to read `TeamClaimTypes.SystemScope` instead. Its own PR (#152) documented this under a "Breaking change" heading, but the version number said "patch". **3.5.4** then added public API (`TeamClaimTypes.SelectedTeamKey`), which is also more than a patch.

Both are published; this does not retroactively fix them. It stops the line from producing more 3.5.x, and the comment on the constant records that bumping it is a manual step.

## Effect

- Next merge to `master` computes **3.6.0** rather than 3.5.5.
- No code, API or behaviour change. CI config only.

## Note on the release run

Merging this queues a release of 3.6.0 whose content is identical to 3.5.4. The `release` job is gated on the `release` environment, so nothing publishes without approval — either approve it as a version marker, or hold this PR and merge it alongside the next feature so 3.6.0 carries real content.
