### PR TITLE
Point the docs domain and package icons at Team

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,5 +158,5 @@ Individual `Add*` methods remain available for partial/custom setups. See the **
 ## Links
 
 - [Implementation Guide](docs/articles/implementation-guide.md)
-- [Documentation site](https://platform.tharga.net)
+- [Documentation site](https://team.tharga.net)
 - [Report an issue](https://github.com/Tharga/Team/issues)

--- a/Tharga.Team.Blazor/Tharga.Team.Blazor.csproj
+++ b/Tharga.Team.Blazor/Tharga.Team.Blazor.csproj
@@ -6,7 +6,7 @@
     <Company>Thargelion AB</Company>
     <Product>Tharga Team Blazor</Product>
     <Description>Team management Blazor components for multi-tenant applications. Works with both Blazor Server and WebAssembly.</Description>
-    <PackageIconUrl>https://thargelion.net/assets/component-platform.png</PackageIconUrl>
+    <PackageIconUrl>https://thargelion.net/assets/component-team.png</PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Tharga.Team.Entra/Tharga.Team.Entra.csproj
+++ b/Tharga.Team.Entra/Tharga.Team.Entra.csproj
@@ -6,7 +6,7 @@
     <Company>Thargelion AB</Company>
     <Product>Tharga Team Entra</Product>
     <Description>Microsoft Entra ID user-directory provider for Tharga Team: verify users against Entra, list directory-only users, and delete users from the directory via Microsoft Graph.</Description>
-    <PackageIconUrl>https://thargelion.net/assets/component-platform.png</PackageIconUrl>
+    <PackageIconUrl>https://thargelion.net/assets/component-team.png</PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Tharga.Team.Images/Tharga.Team.Images.csproj
+++ b/Tharga.Team.Images/Tharga.Team.Images.csproj
@@ -6,7 +6,7 @@
     <Company>Thargelion AB</Company>
     <Product>Tharga Team Images</Product>
     <Description>Image processing for Tharga Team icons — automatic downscaling of uploaded icons via ImageSharp.</Description>
-    <PackageIconUrl>https://thargelion.net/assets/component-platform.png</PackageIconUrl>
+    <PackageIconUrl>https://thargelion.net/assets/component-team.png</PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Tharga.Team.Mcp/Tharga.Team.Mcp.csproj
+++ b/Tharga.Team.Mcp/Tharga.Team.Mcp.csproj
@@ -6,7 +6,7 @@
     <Company>Thargelion AB</Company>
     <Product>Tharga Team Mcp</Product>
     <Description>Team bridge for Tharga.Mcp. Provides Team-backed IMcpContext, scope enforcement, audit logging, and authentication for MCP tool and resource invocations.</Description>
-    <PackageIconUrl>https://thargelion.net/assets/component-platform.png</PackageIconUrl>
+    <PackageIconUrl>https://thargelion.net/assets/component-team.png</PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Tharga.Team.MongoDB/Tharga.Team.MongoDB.csproj
+++ b/Tharga.Team.MongoDB/Tharga.Team.MongoDB.csproj
@@ -6,7 +6,7 @@
     <Company>Thargelion AB</Company>
     <Product>Tharga Team MongoDB</Product>
     <Description>MontoDB Team features for Tharga Blazor.</Description>
-    <PackageIconUrl>https://thargelion.net/assets/component-platform.png</PackageIconUrl>
+    <PackageIconUrl>https://thargelion.net/assets/component-team.png</PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Tharga.Team.Service/README.md
+++ b/Tharga.Team.Service/README.md
@@ -164,7 +164,7 @@ an enricher cannot overwrite a key the toolkit (or an earlier enricher) set — 
 **singleton** (read request state via `IHttpContextAccessor`), and one that throws is logged and skipped so
 enrichment can never fail the audited operation.
 
-See the [implementation guide](https://platform.tharga.net) for the full reference.
+See the [implementation guide](https://team.tharga.net) for the full reference.
 
 ## Capturing the private token
 

--- a/Tharga.Team.Service/Tharga.Team.Service.csproj
+++ b/Tharga.Team.Service/Tharga.Team.Service.csproj
@@ -6,7 +6,7 @@
     <Company>Thargelion AB</Company>
     <Product>Tharga Team Service</Product>
     <Description>Server-side API-key authentication, authorization enforcement, controller registration, OpenAPI/Swagger setup, and audit logging for ASP.NET Core projects.</Description>
-    <PackageIconUrl>https://thargelion.net/assets/component-platform.png</PackageIconUrl>
+    <PackageIconUrl>https://thargelion.net/assets/component-team.png</PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Tharga.Team/Tharga.Team.csproj
+++ b/Tharga.Team/Tharga.Team.csproj
@@ -6,7 +6,7 @@
     <Company>Thargelion AB</Company>
     <Product>Tharga Team</Product>
     <Description>Team features for Tharga Blazor.</Description>
-    <PackageIconUrl>https://thargelion.net/assets/component-platform.png</PackageIconUrl>
+    <PackageIconUrl>https://thargelion.net/assets/component-team.png</PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-platform.tharga.net
+team.tharga.net


### PR DESCRIPTION
Completes the Team rename for the docs domain and the package icons. Follow-up to #156.

## Docs domain — fixes a live hazard

`team.tharga.net` is up, but `docs/CNAME` still said `platform.tharga.net`. That file is copied into the published site (`docfx.json` lists it under `resource`), so **the next docs deploy would have reset the GitHub Pages custom domain and taken `team.tharga.net` down**.

It was deliberately left unchanged in #156, because flipping it before the DNS record existed would have caused exactly the same outage in the other direction. The record now resolves, so this is the right moment.

Also updates two README links that pointed at `platform.tharga.net`, which currently returns 404.

## Package icons

All seven packages now use `component-team.png` instead of `component-platform.png`, same location. Verified the asset returns 200 before pointing at it.

Note: `component-platform.png` must **stay** hosted — packages 3.5.4 and earlier embed that URL, so removing it would retroactively break their icons on nuget.org.

## Effect

Docs publish at `team.tharga.net`; new packages carry the Team icon. No code changes — 993 tests pass unchanged.
