### PR TITLE
Make MCP usable by an API key: accept the credential, and read the team it names

### DIFF
--- a/Tharga.Team.Mcp.Tests/AddTeamTests.cs
+++ b/Tharga.Team.Mcp.Tests/AddTeamTests.cs
@@ -51,6 +51,54 @@ public class AddTeamTests
         Assert.Equal("Host registration.", registered[0].Description);
     }
 
+    /// <summary>
+    /// The credential an MCP caller actually presents. Without this the endpoint's policy names no scheme,
+    /// so it authenticates against the application's default one — OIDC in a Blazor host — and an agent
+    /// with a valid API key is answered with a 302 to a login page (Tharga/Mcp#18).
+    /// </summary>
+    [Fact]
+    public void AddTeam_ContributesTheApiKeyAuthenticationScheme()
+    {
+        var services = new ServiceCollection();
+
+        services.AddThargaMcp(mcp => mcp.AddTeam());
+
+        var options = services.BuildServiceProvider().GetRequiredService<ThargaMcpOptions>();
+        Assert.Contains(ApiKeyConstants.SchemeName, options.AuthenticationSchemes);
+    }
+
+    /// <summary>A host may add its own alongside; contributing must not replace what is already there.</summary>
+    [Fact]
+    public void AddTeam_LeavesAHostContributedSchemeInPlace()
+    {
+        var services = new ServiceCollection();
+
+        services.AddThargaMcp(mcp =>
+        {
+            mcp.Options.AuthenticationSchemes.Add("Cookies");
+            mcp.AddTeam();
+        });
+
+        var options = services.BuildServiceProvider().GetRequiredService<ThargaMcpOptions>();
+        Assert.Equal(["Cookies", ApiKeyConstants.SchemeName], options.AuthenticationSchemes);
+    }
+
+    /// <summary>Registering twice must not duplicate the scheme in the policy.</summary>
+    [Fact]
+    public void AddTeam_DoesNotContributeTheSchemeTwice()
+    {
+        var services = new ServiceCollection();
+
+        services.AddThargaMcp(mcp =>
+        {
+            mcp.AddTeam();
+            mcp.AddTeam();
+        });
+
+        var options = services.BuildServiceProvider().GetRequiredService<ThargaMcpOptions>();
+        Assert.Single(options.AuthenticationSchemes, x => x == ApiKeyConstants.SchemeName);
+    }
+
     [Fact]
     public void ReplacesDefaultContextAccessorWithHttpContextBacked()
     {

--- a/Tharga.Team.Mcp.Tests/TeamResourceProviderTests.cs
+++ b/Tharga.Team.Mcp.Tests/TeamResourceProviderTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using Tharga.Mcp;
 using Tharga.Team.Mcp;
 using Tharga.Team;
@@ -84,7 +84,7 @@ public class TeamResourceProviderTests
         team.Name.Returns("Acme");
         team.Icon.Returns((string)null);
         team.ConsentedRoles.Returns(new[] { "viewer" });
-        _teamService.GetTeamsAsync().Returns(ToAsyncEnumerable(team));
+        _teamService.GetTeamByKeyAsync("T-1").Returns(team);
 
         var sut = new TeamResourceProvider(_teamService, _apiKeyService);
         var content = await sut.ReadResourceAsync(TeamResourceProvider.TeamUri, MakeContext("T-1"), TestContext.Current.CancellationToken);
@@ -96,18 +96,57 @@ public class TeamResourceProviderTests
         Assert.Equal(1, root.GetProperty("consentedRoles").GetArrayLength());
     }
 
+    /// <summary>
+    /// A caller authenticated by API key has no *user*, so scanning the caller's memberships found nothing
+    /// and every read failed — even for the team the key names. Listing advertised the resource and
+    /// reading refused it (Tharga/Mcp probing, 2026-07-31).
+    /// </summary>
     [Fact]
-    public async Task ReadResourceAsync_TeamUri_NotInCallerTeams_Throws()
+    public async Task ReadResourceAsync_TeamUri_SucceedsForACallerWithNoUserMemberships()
     {
-        // The MCP caller's TeamKey claim says T-1 but GetTeamsAsync() returns a different team.
-        var otherTeam = Substitute.For<ITeam>();
-        otherTeam.Key.Returns("T-OTHER");
-        _teamService.GetTeamsAsync().Returns(ToAsyncEnumerable(otherTeam));
+        var team = Substitute.For<ITeam>();
+        team.Key.Returns("T-1");
+        team.Name.Returns("Acme");
+        team.ConsentedRoles.Returns(Array.Empty<string>());
+        _teamService.GetTeamByKeyAsync("T-1").Returns(team);
+        _teamService.GetTeamsAsync().Returns(ToAsyncEnumerable<ITeam>());   // no memberships, as for an API key
+
+        var sut = new TeamResourceProvider(_teamService, _apiKeyService);
+        var content = await sut.ReadResourceAsync(TeamResourceProvider.TeamUri, MakeContext("T-1"), TestContext.Current.CancellationToken);
+
+        using var doc = JsonDocument.Parse(content.Text);
+        Assert.Equal("T-1", doc.RootElement.GetProperty("key").GetString());
+    }
+
+    /// <summary>
+    /// The safety property the fix rests on. `GetTeamByKeyAsync` is deliberately unauthorized, so reading
+    /// by key is only safe while the key comes from the caller's own server-issued `TeamKey` claim and
+    /// never from the request. This pins that: the team read is always the one the context names.
+    /// </summary>
+    [Fact]
+    public async Task ReadResourceAsync_TeamUri_ReadsOnlyTheTeamTheContextNames()
+    {
+        var own = Substitute.For<ITeam>();
+        own.Key.Returns("T-1");
+        own.ConsentedRoles.Returns(Array.Empty<string>());
+        _teamService.GetTeamByKeyAsync("T-1").Returns(own);
+
+        var sut = new TeamResourceProvider(_teamService, _apiKeyService);
+        await sut.ReadResourceAsync(TeamResourceProvider.TeamUri, MakeContext("T-1"), TestContext.Current.CancellationToken);
+
+        await _teamService.Received(1).GetTeamByKeyAsync("T-1");
+        await _teamService.DidNotReceive().GetTeamByKeyAsync(Arg.Is<string>(x => x != "T-1"));
+    }
+
+    [Fact]
+    public async Task ReadResourceAsync_TeamUri_UnknownTeam_Throws()
+    {
+        _teamService.GetTeamByKeyAsync("T-9").Returns((ITeam)null);
 
         var sut = new TeamResourceProvider(_teamService, _apiKeyService);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            sut.ReadResourceAsync(TeamResourceProvider.TeamUri, MakeContext("T-1"), TestContext.Current.CancellationToken));
+            sut.ReadResourceAsync(TeamResourceProvider.TeamUri, MakeContext("T-9"), TestContext.Current.CancellationToken));
     }
 
     [Fact]

--- a/Tharga.Team.Mcp/McpTeamBuilderExtensions.cs
+++ b/Tharga.Team.Mcp/McpTeamBuilderExtensions.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Tharga.Mcp;
@@ -33,6 +33,15 @@ public static class McpTeamBuilderExtensions
         builder.Services.AddSingleton<IMcpContextAccessor, HttpContextMcpContextAccessor>();
 
         builder.Services.TryAddSingleton<IMcpScopeChecker, McpScopeChecker>();
+
+        // MCP callers are agents presenting an API key — there is no user. Contribute the scheme so
+        // RequireAuth accepts that credential without the host knowing about schemes at all; a bare
+        // RequireAuthorization() resolves to the application's default scheme, which in a Blazor host is
+        // OIDC, and answered an agent with a 302 to a login page (Tharga/Mcp#18).
+        if (!builder.Options.AuthenticationSchemes.Contains(ApiKeyConstants.SchemeName))
+        {
+            builder.Options.AuthenticationSchemes.Add(ApiKeyConstants.SchemeName);
+        }
 
         // Register built-in mcp:* scopes into both registries, because both routes to holding one are
         // legitimate: an access level grants it inside a team, while an app role or a system API key

--- a/Tharga.Team.Mcp/README.md
+++ b/Tharga.Team.Mcp/README.md
@@ -1,4 +1,4 @@
-# Tharga Team Mcp
+﻿# Tharga Team Mcp
 [![NuGet](https://img.shields.io/nuget/v/Tharga.Team.Mcp)](https://www.nuget.org/packages/Tharga.Team.Mcp)
 ![Nuget](https://img.shields.io/nuget/dt/Tharga.Team.Mcp)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
@@ -63,6 +63,27 @@ this package or `Tharga.MongoDB.Mcp` calls it for you.
 > system claims, so an access-level grant could never satisfy it and a tool calling
 > `Require(McpScopes.Discover)` rejected every caller — including a team Owner. If you wrote a test
 > asserting that rejection, it now passes the caller instead.
+
+## Authentication
+
+`mcp.AddTeam()` contributes the API-key scheme to the MCP endpoint, so the default
+`ThargaMcpOptions.RequireAuth = true` accepts an API key with no further configuration:
+
+```csharp
+builder.Services.AddThargaMcp(mcp => mcp.AddTeam());
+app.UseThargaMcp();
+```
+
+That matters because MCP callers are agents — there is normally no user, so an API key is the expected
+credential. Before `Tharga.Mcp` 1.0.1, `RequireAuth` emitted a policy naming no scheme, which
+authenticated against the application's **default** scheme; in a Blazor host that is OIDC, so a valid key
+was answered with a 302 to a login page ([Tharga/Mcp#18](https://github.com/Tharga/Mcp/issues/18)).
+
+Add your own scheme alongside if you also want a signed-in user to reach the endpoint:
+
+```csharp
+mcp.Options.AuthenticationSchemes.Add(CookieAuthenticationDefaults.AuthenticationScheme);
+```
 
 ## User and team resources
 

--- a/Tharga.Team.Mcp/TeamResourceProvider.cs
+++ b/Tharga.Team.Mcp/TeamResourceProvider.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using Tharga.Mcp;
 using Tharga.Team;
 
@@ -90,14 +90,23 @@ public sealed class TeamResourceProvider : IMcpResourceProvider
         };
     }
 
+    /// <remarks>
+    /// Reads by key rather than by scanning the caller's memberships. <c>GetTeamsAsync()</c> resolves the
+    /// current <i>user</i>, so an API key — authenticated, and carrying the team in a server-issued claim —
+    /// had no teams and could never read the very resource <c>ListResourcesAsync</c> had just advertised
+    /// to it. Listing gated on the claim while reading gated on membership, and the two disagreed.
+    /// <para>
+    /// <b>Safe only because <paramref name="teamKey"/> comes from <c>IMcpContext.TeamId</c></b> — the
+    /// caller's own <c>TeamKey</c> claim, issued by the server — and never from the request. A caller can
+    /// therefore only ever name its own team. <see cref="ITeamService.GetTeamByKeyAsync"/> is deliberately
+    /// unauthorized ("regardless of the caller's membership"), so passing a caller-supplied key here would
+    /// be a cross-team read with nothing to stop it.
+    /// </para>
+    /// </remarks>
     private async Task<McpResourceContent> ReadTeamAsync(string teamKey, CancellationToken cancellationToken)
     {
-        ITeam team = null;
-        await foreach (var candidate in _teamService.GetTeamsAsync().WithCancellation(cancellationToken))
-        {
-            if (candidate.Key == teamKey) { team = candidate; break; }
-        }
-        if (team == null) throw new InvalidOperationException($"Team '{teamKey}' not found for the caller.");
+        var team = await _teamService.GetTeamByKeyAsync(teamKey);
+        if (team == null) throw new InvalidOperationException($"Team '{teamKey}' not found.");
 
         var payload = new
         {

--- a/Tharga.Team.Mcp/Tharga.Team.Mcp.csproj
+++ b/Tharga.Team.Mcp/Tharga.Team.Mcp.csproj
@@ -37,7 +37,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Tharga.Mcp" Version="1.0.0" />
+    <PackageReference Include="Tharga.Mcp" Version="1.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Team.Service\Tharga.Team.Service.csproj" />

--- a/Tharga.Team.Sample/Program.cs
+++ b/Tharga.Team.Sample/Program.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Authentication.Cookies;
-using Radzen;
+﻿using Radzen;
 using Serilog;
 using Serilog.Events;
 using Tharga.Mcp;
@@ -15,8 +14,6 @@ using Tharga.Team.Images;
 using Tharga.Team.MongoDB;
 using Tharga.Team.Service;
 using Tharga.Team.Service.Audit;
-
-const string McpAccessPolicy = "McpAccess";
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -151,22 +148,10 @@ if (!string.IsNullOrEmpty(builder.Configuration["AzureAd:ClientSecret"]))
 
 builder.Services.AddThargaMcp(mcp =>
 {
-    // TEMPORARY WORKAROUND — remove when Tharga/Mcp#18 ships.
-    // RequireAuth off so we can apply our own policy below. The built-in one calls a bare
-    // .RequireAuthorization(), which uses the DEFAULT authentication scheme — OIDC here — so an API key
-    // is never consulted and a key-authenticated caller is redirected to the login page instead. Once
-    // AddTeam() contributes the API-key scheme, this whole block collapses back to mcp.AddTeam() plus a
-    // bare app.UseThargaMcp().
-    mcp.Options.RequireAuth = false;
+    // RequireAuth is on by default and now accepts an API key: AddTeam() contributes the API-key scheme,
+    // so the endpoint no longer falls back to the application's default (OIDC) and reject agents.
     mcp.AddTeam();
 });
-
-// Accept either an API key or an interactive sign-in, so /mcp can be explored both ways and the
-// difference in what each caller sees is the point of the demo.
-builder.Services.AddAuthorizationBuilder()
-    .AddPolicy(McpAccessPolicy, policy => policy
-        .AddAuthenticationSchemes(ApiKeyConstants.SchemeName, CookieAuthenticationDefaults.AuthenticationScheme)
-        .RequireAuthenticatedUser());
 
 // TeamAccessInterceptor is deliberately NOT registered yet. Claim construction reads the user record to
 // decide what the caller may do, so it necessarily precedes any authorization decision — and every
@@ -199,7 +184,7 @@ app.UseHttpsRedirection();
 app.UseAntiforgery();
 
 app.UseThargaTeam();
-app.UseThargaMcp().RequireAuthorization(McpAccessPolicy);
+app.UseThargaMcp();
 
 app.MapStaticAssets();
 app.MapRazorComponents<App>()

--- a/Tharga.Team/IApiKeyAdministrationService.cs
+++ b/Tharga.Team/IApiKeyAdministrationService.cs
@@ -1,4 +1,4 @@
-namespace Tharga.Team;
+﻿namespace Tharga.Team;
 
 /// <summary>
 /// Service for managing and validating API keys.
@@ -17,7 +17,14 @@ public interface IApiKeyAdministrationService
     /// <summary>Generates a new API key value for an existing key entry. Returns the entity with the raw key visible once.</summary>
     Task<IApiKey> RefreshKeyAsync(string teamKey, string key);
 
-    /// <summary>Locks an API key so it can no longer be used for authentication. Verifies team ownership.</summary>
+    /// <summary>
+    /// Discards the stored secret so the raw key value can never be retrieved again. Verifies team ownership.
+    /// </summary>
+    /// <remarks>
+    /// <b>This does not disable the key.</b> A locked key still authenticates — locking only makes the
+    /// value unrecoverable, which is why <c>ApiKeyOptions.AutoLockKeys</c> can lock every key at creation
+    /// without breaking anything. To stop a key working, delete it; there is no disable yet.
+    /// </remarks>
     Task LockKeyAsync(string teamKey, string key);
 
     /// <summary>Deletes an API key. Verifies team ownership.</summary>
@@ -48,7 +55,10 @@ public interface IApiKeyAdministrationService
     /// <summary>Regenerates a system key's raw value. Returns the entity with the raw key visible once.</summary>
     Task<IApiKey> RefreshSystemKeyAsync(string key);
 
-    /// <summary>Locks a system API key so it can no longer authenticate.</summary>
+    /// <summary>
+    /// Discards the stored secret of a system API key so its raw value can never be retrieved again.
+    /// </summary>
+    /// <remarks><b>This does not disable the key</b> — see <see cref="LockKeyAsync"/>.</remarks>
     Task LockSystemKeyAsync(string key);
 
     /// <summary>Deletes a system API key.</summary>


### PR DESCRIPTION
MCP now works end to end for an API-key caller — authentication *and* reading — with no host configuration. Both halves were broken, in different ways, and fixing only one would have shipped an endpoint that authenticates and then refuses.

## Authentication: `RequireAuth` accepts an API key

MCP callers are agents. There is normally no user, so an API key is the expected credential — and it was the one configuration that could not work.

`UseThargaMcp()` emitted a bare `.RequireAuthorization()`, which authenticates against the application's **default** scheme. In a Blazor host that is OIDC, so a valid key was answered with a **302 to a login page**.

Fixed upstream in [Tharga/Mcp#18](https://github.com/Tharga/Mcp/issues/18) (`Tharga.Mcp` 1.0.1) by letting options carry the schemes. This PR consumes it: **`AddTeam()` contributes `ApiKeyConstants.SchemeName`**, so a host gets a working endpoint without knowing schemes exist.

```csharp
builder.Services.AddThargaMcp(mcp => mcp.AddTeam());
app.UseThargaMcp();
```

The sample's workaround — `RequireAuth = false` plus a hand-rolled `McpAccess` policy — is deleted. Add your own scheme alongside if a signed-in user should also reach the endpoint:

```csharp
mcp.Options.AuthenticationSchemes.Add(CookieAuthenticationDefaults.AuthenticationScheme);
```

## Reading: resolve the team by its claim, not by user membership

`TeamResourceProvider.ReadTeamAsync` scanned the caller's memberships for a team **whose key it already held**:

```csharp
await foreach (var candidate in _teamService.GetTeamsAsync())   // resolves the current USER
    if (candidate.Key == teamKey) { team = candidate; break; }
```

An API key is authenticated and carries its team in a server-issued claim, but has no *user* — so it had no memberships, and every read failed. `ListResourcesAsync` gated on the claim and advertised three resources that `ReadResourceAsync` then refused. One feature, two different notions of "the caller's current team".

It now reads by key via `ITeamService.GetTeamByKeyAsync`, which was added after this provider was written.

> **Safe only because the key comes from `IMcpContext.TeamId`** — the caller's own `TeamKey` claim — and never from the request, so a caller can only ever name its own team. `GetTeamByKeyAsync` is deliberately unauthorized ("regardless of the caller's membership"), so passing a caller-supplied key there would be a cross-team read with nothing to stop it. A test asserts the read only ever touches the team the context names.

## Also here

**Two misleading doc lines corrected.** `LockKeyAsync` and `LockSystemKeyAsync` both claimed locking stops a key authenticating. It does not — it discards the stored secret so the raw value cannot be retrieved, which is why `AutoLockKeys` can lock every key at creation without breaking anything. Both now say what locking does and state plainly that **there is no disable**.

## Verified against a running app

With two real team keys: authentication succeeds, all three team resources return data, and `resources/list` and `resources/read` finally agree.

Worth knowing, and recorded on `planned/06-audit-access-verification.md` rather than changed here: **no read path consults access level, scopes, or consent.** A level-1 key and a level-2 key return identical data, and revoking the team's consent changed nothing. Holding a team's key grants full read of that team. That may be the intended design — a key is the team's credential — but it is undocumented and unasserted, and deciding it belongs with the rest of the access matrix.

## Upgrading

Nothing required. If you turned `RequireAuth` off and hand-rolled a policy to make API keys work, you can now delete it.

No `MAJOR_MINOR` bump — nothing here requires a consumer to act.

1104 tests pass across 6 projects.
