### PR TITLE
Read the audit log over REST, sharing one access rule with the view

### DIFF
--- a/Tharga.Team.Blazor/Features/Audit/AuditLogView.razor.cs
+++ b/Tharga.Team.Blazor/Features/Audit/AuditLogView.razor.cs
@@ -80,13 +80,9 @@ public partial class AuditLogView : ComponentBase
         var authState = await AuthStateProvider.GetAuthenticationStateAsync();
         var user = authState.User;
 
-        // Pinned to a team: audit:read on that team is enough, however the caller came by it.
-        // Unpinned: the view queries every team, so it takes a system-wide grant. Without the distinction a
-        // team administrator whose access level includes audit:read could read the whole system's log.
-        _hasAccess = PinnedFilter?.TeamKey is { } pinnedTeam
-            ? TeamScopeGate.HasTeamScope(user, AuditScopes.Read, pinnedTeam)
-              || TeamScopeGate.HasSystemScope(user, AuditScopes.Read)
-            : TeamScopeGate.HasSystemScope(user, AuditScopes.Read);
+        // Shared with the REST endpoint rather than restated here: the rule decided in two places is the
+        // rule that drifts, and the surface that drifts is the one nobody tested.
+        _hasAccess = AuditAccess.CanRead(user, PinnedFilter?.TeamKey);
         _accessResolved = true;
         if (!_hasAccess) return;
 

--- a/Tharga.Team.Sample/Program.cs
+++ b/Tharga.Team.Sample/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Radzen;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Serilog;
 using Serilog.Events;
 using Tharga.Mcp;

--- a/Tharga.Team.Sample/Program.cs
+++ b/Tharga.Team.Sample/Program.cs
@@ -128,6 +128,11 @@ builder.AddThargaTeam(o =>
         roles.Map("Developer", "system:metrics:read", "mcp:discover", ApiKeyScopes.SystemManage, AuditScopes.Read, SystemUserScopes.Manage, SystemTeamScopes.Delete);
     };
 
+    // Controllers on, which exposes the toolkit's own REST endpoints — GET /api/audit — plus Swagger at
+    // /swagger. The endpoints accept an API key by default; add a cookie scheme to reach them signed in.
+    o.Controllers = new ThargaControllerOptions { SwaggerTitle = "Tharga Team Sample API" };
+    o.Controllers.AuthenticationSchemes.Add(CookieAuthenticationDefaults.AuthenticationScheme);
+
     // Logger | MongoDB so the audit entries are both logged and queryable by AuditLogView — the default
     // is Logger-only, which leaves the /audit page empty.
     o.Audit = new AuditOptions { StorageMode = AuditStorageMode.Logger | AuditStorageMode.MongoDB };

--- a/Tharga.Team.Service.Tests/Audit/AuditAccessTests.cs
+++ b/Tharga.Team.Service.Tests/Audit/AuditAccessTests.cs
@@ -1,0 +1,113 @@
+using System.Security.Claims;
+using Tharga.Team.Service.Audit;
+
+namespace Tharga.Team.Service.Tests.Audit;
+
+/// <summary>
+/// Who may read the audit log, and for which team. Shared by the Blazor view and the REST endpoint, so
+/// these assertions cover both surfaces at once — which is the point of having one rule.
+/// </summary>
+public class AuditAccessTests
+{
+    private const string TeamA = "team-a";
+    private const string TeamB = "team-b";
+
+    [Fact]
+    public void NoPrincipal_CannotRead()
+    {
+        Assert.False(AuditAccess.CanRead(null, TeamA));
+        Assert.False(AuditAccess.CanRead(null, null));
+    }
+
+    [Fact]
+    public void AnonymousPrincipal_CannotRead()
+    {
+        var anonymous = new ClaimsPrincipal(new ClaimsIdentity());
+
+        Assert.False(AuditAccess.CanRead(anonymous, TeamA));
+        Assert.False(AuditAccess.CanRead(anonymous, null));
+    }
+
+    [Fact]
+    public void AuthenticatedWithoutTheScope_CannotRead()
+    {
+        var caller = Principal(teamKey: TeamA);
+
+        Assert.False(AuditAccess.CanRead(caller, TeamA));
+        Assert.False(AuditAccess.CanRead(caller, null));
+    }
+
+    [Fact]
+    public void ATeamGrant_ReadsItsOwnTeam()
+    {
+        var caller = Principal(teamKey: TeamA, teamScopes: [AuditScopes.Read]);
+
+        Assert.True(AuditAccess.CanRead(caller, TeamA));
+    }
+
+    /// <summary>
+    /// <b>I3.</b> A team grant is issued for the selected team, so it must not reach another one — even
+    /// when the caller names that team explicitly. Knowing a team key is not authority over it.
+    /// </summary>
+    [Fact]
+    public void ATeamGrant_CannotReachAnotherTeam()
+    {
+        var caller = Principal(teamKey: TeamA, teamScopes: [AuditScopes.Read]);
+
+        Assert.False(AuditAccess.CanRead(caller, TeamB));
+    }
+
+    /// <summary>
+    /// <b>I1.</b> Querying without a team spans every team, so a team grant must not satisfy it. Accepting
+    /// one here is precisely the hole the Scope / SystemScope provenance split closed: a team
+    /// administrator could read the whole system's log.
+    /// </summary>
+    [Fact]
+    public void ATeamGrant_CannotReadAcrossAllTeams()
+    {
+        var caller = Principal(teamKey: TeamA, teamScopes: [AuditScopes.Read]);
+
+        Assert.False(AuditAccess.CanRead(caller, teamKey: null));
+    }
+
+    [Fact]
+    public void ASystemGrant_ReadsAcrossAllTeams()
+    {
+        var caller = Principal(systemScopes: [AuditScopes.Read]);
+
+        Assert.True(AuditAccess.CanRead(caller, teamKey: null));
+    }
+
+    /// <summary>A system grant is team-independent, so it reaches any named team as well.</summary>
+    [Theory]
+    [InlineData(TeamA)]
+    [InlineData(TeamB)]
+    public void ASystemGrant_ReadsAnyNamedTeam(string teamKey)
+    {
+        var caller = Principal(systemScopes: [AuditScopes.Read]);
+
+        Assert.True(AuditAccess.CanRead(caller, teamKey));
+    }
+
+    /// <summary>
+    /// The scope must be the right one. Holding some other audit-adjacent grant is not holding this one.
+    /// </summary>
+    [Fact]
+    public void ADifferentScope_DoesNotGrantAuditRead()
+    {
+        var caller = Principal(teamKey: TeamA, teamScopes: ["team:manage"], systemScopes: ["users:manage"]);
+
+        Assert.False(AuditAccess.CanRead(caller, TeamA));
+        Assert.False(AuditAccess.CanRead(caller, null));
+    }
+
+    private static ClaimsPrincipal Principal(string teamKey = null, string[] teamScopes = null, string[] systemScopes = null)
+    {
+        var claims = new List<Claim>();
+        if (teamKey != null) claims.Add(new Claim(TeamClaimTypes.TeamKey, teamKey));
+        foreach (var scope in teamScopes ?? []) claims.Add(new Claim(TeamClaimTypes.Scope, scope));
+        foreach (var scope in systemScopes ?? []) claims.Add(new Claim(TeamClaimTypes.SystemScope, scope));
+
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+    }
+}

--- a/Tharga.Team.Service/ApiKeyConstants.cs
+++ b/Tharga.Team.Service/ApiKeyConstants.cs
@@ -1,4 +1,4 @@
-using Tharga.Team;
+﻿using Tharga.Team;
 
 namespace Tharga.Team.Service;
 
@@ -26,6 +26,12 @@ public static class ApiKeyConstants
 
     /// <summary>OpenAPI security scheme identifier.</summary>
     public const string OpenApiSchemeId = "ApiKey";
+
+    /// <summary>
+    /// Authorization policy for the toolkit's own HTTP endpoints. Requires an authenticated caller against
+    /// <c>ThargaControllerOptions.AuthenticationSchemes</c> — the API-key scheme by default.
+    /// </summary>
+    public const string ThargaApiPolicyName = "ThargaApiPolicy";
 
     /// <summary>Authorization policy name for system-level API keys (keys not bound to a team).</summary>
     public const string SystemPolicyName = "SystemApiKeyPolicy";

--- a/Tharga.Team.Service/Audit/AuditAccess.cs
+++ b/Tharga.Team.Service/Audit/AuditAccess.cs
@@ -1,0 +1,41 @@
+using System.Security.Claims;
+
+namespace Tharga.Team.Service.Audit;
+
+/// <summary>
+/// Whether a caller may read the audit log, and for which team.
+/// </summary>
+/// <remarks>
+/// Extracted so every surface — the Blazor view, the REST endpoint, and anything added later — asks the
+/// same question of the same code. The rule restated per surface is the rule that drifts: three places
+/// deciding "may this caller read audit" is three chances for one of them to be wrong, and the one that
+/// is wrong is the one nobody tested.
+/// </remarks>
+public static class AuditAccess
+{
+    /// <summary>
+    /// Whether <paramref name="principal"/> may read audit entries for <paramref name="teamKey"/>, or
+    /// across every team when it is null.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For one team:</b> <c>audit:read</c> held on that team, however the caller came by it — an
+    /// access level, a tenant role, a scope override — or held system-wide.
+    /// </para>
+    /// <para>
+    /// <b>Across all teams:</b> a system grant only. A team grant is issued for the selected team, so
+    /// accepting it here would let a team administrator read every team's log — the hole the
+    /// <c>Scope</c> / <c>SystemScope</c> provenance split closed.
+    /// </para>
+    /// </remarks>
+    public static bool CanRead(ClaimsPrincipal principal, string teamKey)
+    {
+        if (principal == null) return false;
+
+        if (string.IsNullOrEmpty(teamKey))
+            return TeamScopePolicy.HasSystemScope(principal, AuditScopes.Read);
+
+        return TeamScopePolicy.HasTeamScope(principal, AuditScopes.Read, teamKey)
+               || TeamScopePolicy.HasSystemScope(principal, AuditScopes.Read);
+    }
+}

--- a/Tharga.Team.Service/Audit/AuditController.cs
+++ b/Tharga.Team.Service/Audit/AuditController.cs
@@ -1,0 +1,68 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Tharga.Team.Service.Audit;
+
+/// <summary>
+/// Reads the audit log over HTTP, authorized identically to the Blazor view and the MCP surface.
+/// </summary>
+/// <remarks>
+/// Read-only by design: nothing about exposing the audit log justifies an endpoint that changes it.
+/// </remarks>
+[ApiController]
+[Route("api/audit")]
+[Authorize(Policy = ApiKeyConstants.ThargaApiPolicyName)]
+public class AuditController(CompositeAuditLogger auditLogger) : ControllerBase
+{
+    /// <summary>Audit entries, newest first.</summary>
+    /// <param name="teamKey">
+    /// Restrict to one team. Omit to query across every team, which requires a <b>system</b>
+    /// <c>audit:read</c> grant — a team grant authorizes only its own team.
+    /// </param>
+    /// <param name="from">Earliest timestamp, inclusive.</param>
+    /// <param name="to">Latest timestamp, inclusive.</param>
+    /// <param name="feature">Restrict to one feature — the left half of a scope, e.g. <c>apikey</c>.</param>
+    /// <param name="action">Restrict to one action — the right half, e.g. <c>manage</c>.</param>
+    /// <param name="success">Restrict to successful or failed entries.</param>
+    /// <param name="skip">Entries to skip, for paging.</param>
+    /// <param name="take">Maximum entries to return. Capped at 500.</param>
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult<AuditQueryResult>> GetAsync(
+        [FromQuery] string teamKey = null,
+        [FromQuery] DateTime? from = null,
+        [FromQuery] DateTime? to = null,
+        [FromQuery] string feature = null,
+        [FromQuery] string action = null,
+        [FromQuery] bool? success = null,
+        [FromQuery] int skip = 0,
+        [FromQuery] int take = 100)
+    {
+        // Forbid rather than 404: the caller is authenticated and the resource exists, they simply may not
+        // read it. A 404 here would also leak whether a team key is real, by answering differently for one
+        // that is not.
+        if (!AuditAccess.CanRead(User, teamKey))
+            return Forbid();
+
+        var result = await auditLogger.QueryAsync(new AuditQuery
+        {
+            // Bound by the same value the authorization check used, so a caller authorized for one team
+            // cannot widen the query past it.
+            TeamKey = teamKey,
+            From = from,
+            To = to,
+            Feature = feature,
+            Action = action,
+            Success = success,
+            Skip = skip < 0 ? 0 : skip,
+            Take = Math.Clamp(take, 1, MaxTake),
+        });
+
+        return Ok(result);
+    }
+
+    /// <summary>Ceiling on <c>take</c>, so one request cannot pull the whole collection.</summary>
+    private const int MaxTake = 500;
+}

--- a/Tharga.Team.Service/ControllersRegistration.cs
+++ b/Tharga.Team.Service/ControllersRegistration.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi;
 using Tharga.Toolkit.Password;
@@ -20,6 +20,17 @@ public static class ControllersRegistration
 
         services.AddSingleton(options);
         services.AddControllers();
+
+        // The policy the toolkit's own endpoints use, built from the configured schemes so an API key is
+        // accepted without the host naming a scheme — see ThargaControllerOptions.AuthenticationSchemes.
+        services.AddAuthorizationBuilder()
+            .AddPolicy(ApiKeyConstants.ThargaApiPolicyName, policy =>
+            {
+                if (options.AuthenticationSchemes.Count > 0)
+                    policy.AddAuthenticationSchemes([.. options.AuthenticationSchemes]);
+
+                policy.RequireAuthenticatedUser();
+            });
 
 #if NET10_0_OR_GREATER
         services.AddOpenApi(o =>

--- a/Tharga.Team.Service/README.md
+++ b/Tharga.Team.Service/README.md
@@ -60,6 +60,8 @@ Denials are `403` rather than `404`, so they do not reveal whether a team exists
 to the API-key scheme. Add your own to also admit a signed-in user:
 
 ```csharp
+using Microsoft.AspNetCore.Authentication.Cookies;
+
 builder.Services.AddThargaControllers(o =>
     o.AuthenticationSchemes.Add(CookieAuthenticationDefaults.AuthenticationScheme));
 ```

--- a/Tharga.Team.Service/README.md
+++ b/Tharga.Team.Service/README.md
@@ -36,6 +36,38 @@ app.UseAuthorization();
 app.Run();
 ```
 
+## Reading the audit log over REST
+
+`AddThargaControllers` registers one controller of its own — `GET /api/audit` — so audit data is reachable
+from a script or an agent, not only from the Blazor view.
+
+```
+GET /api/audit?teamKey=ABC123&from=2026-01-01&take=100
+X-API-KEY: <key>
+```
+
+Filters: `teamKey`, `from`, `to`, `feature`, `action`, `success`, `skip`, `take` (capped at 500).
+**Omitting `teamKey` reads across all teams** and requires a *system* `audit:read` grant.
+
+Authorization is the same `AuditAccess.CanRead` rule the Blazor `AuditLogView` uses, so the two surfaces
+cannot drift. A team grant reaches only its own team; `audit:read` is registered at
+`AccessLevel.Administrator`, so Viewer- and User-level callers are refused even for their own team.
+Denials are `403` rather than `404`, so they do not reveal whether a team exists.
+
+## Which credentials reach the API
+
+`ThargaControllerOptions.AuthenticationSchemes` lists the schemes Tharga's controllers accept, defaulting
+to the API-key scheme. Add your own to also admit a signed-in user:
+
+```csharp
+builder.Services.AddThargaControllers(o =>
+    o.AuthenticationSchemes.Add(CookieAuthenticationDefaults.AuthenticationScheme));
+```
+
+A policy naming no scheme falls back to the application's **default** scheme — OIDC in a Blazor host — so
+an unauthenticated API call gets a 302 to a login page rather than a 401, and an agent following it
+receives HTML with a 200. Naming schemes explicitly is what avoids that.
+
 ## Customizing the OpenAPI document
 
 `AddThargaControllers` owns the OpenAPI document (it registers the API-key security scheme on it). To add your own `IOpenApiDocumentTransformer` / `IOpenApiOperationTransformer` — for example, to filter the generated spec down to the operations the current caller is authorized for — use the `ConfigureOpenApi` hook instead of calling `AddOpenApi("v1", …)` yourself:

--- a/Tharga.Team.Service/ThargaControllerOptions.cs
+++ b/Tharga.Team.Service/ThargaControllerOptions.cs
@@ -1,4 +1,4 @@
-#if NET10_0_OR_GREATER
+﻿#if NET10_0_OR_GREATER
 using Microsoft.AspNetCore.OpenApi;
 #endif
 
@@ -18,6 +18,21 @@ public class ThargaControllerOptions
     /// Swagger UI route prefix. Defaults to "swagger".
     /// </summary>
     public string SwaggerRoutePrefix { get; set; } = "swagger";
+
+    /// <summary>
+    /// Authentication schemes the toolkit's HTTP endpoints accept. Defaults to the API-key scheme.
+    /// </summary>
+    /// <remarks>
+    /// Named explicitly rather than left to the application's default scheme. A bare <c>[Authorize]</c>
+    /// authenticates against the default, which in a host with interactive sign-in is OIDC — so an
+    /// API-key caller would be answered with a redirect to a login page instead of data. That is exactly
+    /// the defect fixed upstream in <see href="https://github.com/Tharga/Mcp/issues/18">Tharga/Mcp#18</see>
+    /// for the MCP endpoint, and it would reappear here unmodified.
+    /// <para>
+    /// Add your own — a cookie scheme, say — to let a signed-in user reach these endpoints too.
+    /// </para>
+    /// </remarks>
+    public IList<string> AuthenticationSchemes { get; } = [ApiKeyConstants.SchemeName];
 
 #if NET10_0_OR_GREATER
     internal Action<OpenApiOptions> OpenApiConfigure { get; private set; }

--- a/docs/articles/implementation-guide.md
+++ b/docs/articles/implementation-guide.md
@@ -329,6 +329,8 @@ builder.Services.AddThargaControllers(o =>
 scheme alone, which is what an API caller normally presents:
 
 ```csharp
+using Microsoft.AspNetCore.Authentication.Cookies;
+
 builder.Services.AddThargaControllers(o =>
 {
     o.AuthenticationSchemes.Add(CookieAuthenticationDefaults.AuthenticationScheme);   // also allow a signed-in user

--- a/docs/articles/implementation-guide.md
+++ b/docs/articles/implementation-guide.md
@@ -323,6 +323,24 @@ builder.Services.AddThargaControllers(o =>
 });
 ```
 
+#### Which credentials reach the API
+
+`AuthenticationSchemes` lists the schemes Tharga's own controllers accept. It defaults to the API-key
+scheme alone, which is what an API caller normally presents:
+
+```csharp
+builder.Services.AddThargaControllers(o =>
+{
+    o.AuthenticationSchemes.Add(CookieAuthenticationDefaults.AuthenticationScheme);   // also allow a signed-in user
+});
+```
+
+Naming the schemes up front matters more than it looks. A policy that names **no** scheme authenticates
+against the application's *default* scheme — in a Blazor host that is OIDC, so an unauthenticated API call
+is answered with a **302 to a login page** instead of a `401`. An agent or script following that redirect
+receives HTML and a `200`. This is the same trap as [`Tharga/Mcp#18`](https://github.com/Tharga/Mcp/issues/18),
+which is why both surfaces now configure schemes explicitly.
+
 ### Customizing the OpenAPI document (.NET 10+)
 
 `AddThargaControllers` owns the OpenAPI document and registers the API-key security scheme on it. To add your own `IOpenApiDocumentTransformer` / `IOpenApiOperationTransformer` — for example, per-scope operation filtering so the generated spec only exposes operations the caller is authorized for — use the `ConfigureOpenApi` hook rather than calling `AddOpenApi("v1", …)` directly:
@@ -340,6 +358,42 @@ The callback receives the same `OpenApiOptions` Tharga configures, so your trans
 - OpenAPI endpoint with API key security scheme
 - Swagger UI at `/<SwaggerRoutePrefix>`
 - API key header convention (`X-API-KEY`)
+- **`GET /api/audit`** — the audit log over REST (see below)
+
+### Reading the audit log over REST
+
+`AddThargaControllers` ships one controller of its own, so audit data is reachable from a script or an
+agent rather than only from the Blazor view.
+
+```
+GET /api/audit?teamKey=ABC123&from=2026-01-01&take=100
+X-API-KEY: <key>
+```
+
+| Parameter | Meaning |
+|---|---|
+| `teamKey` | Restrict to one team. **Omit to read across all teams** — that requires a *system* `audit:read` grant |
+| `from`, `to` | Time window |
+| `feature`, `action` | Filter by what was done |
+| `success` | `true`/`false` |
+| `skip`, `take` | Paging; `take` is capped at 500 |
+
+Authorization is the **same rule the Blazor view uses** — both call `AuditAccess.CanRead`, so the two
+surfaces cannot drift apart as either changes:
+
+| Caller | Result |
+|---|---|
+| No credential | `401` |
+| Holds team `audit:read` for that team | `200` |
+| Holds team `audit:read` for a *different* team | `403` |
+| Omits `teamKey` without a **system** `audit:read` grant | `403` |
+| Holds system `audit:read` | `200`, any team or all teams |
+
+`audit:read` is registered at `AccessLevel.Administrator`, so a Viewer- or User-level caller is refused
+even for its own team.
+
+Denials are `403`, never `404` — a `404` would confirm whether a team exists to a caller not allowed to
+know that.
 
 ### Usage
 


### PR DESCRIPTION
Adds `GET /api/audit` — the first controller the toolkit ships — so audit data is reachable from a script or an agent, not only from the Blazor view.

## One rule, two surfaces

The point of this isn't the endpoint; it's that the endpoint and the view **cannot disagree**. Both now call the same function:

```csharp
_hasAccess = AuditAccess.CanRead(user, PinnedFilter?.TeamKey);
```

`AuditLogView` previously carried three inline lines of the same logic. A REST endpoint written separately would have been a second copy free to drift. Ten unit tests cover both surfaces at once.

## Verified live against the sample

Two real API keys on team `GDAJWNH2XULZP9`:

| Caller | Own team | All teams | Another team |
|---|---|---|---|
| No credential | — | **401** | — |
| User level (2) | **403** | **403** | — |
| Administrator level (1) | **200** (142 entries) | **403** | **403** |

Confirms **I1** from the audit-access spec — a team grant does not span the system — and shows access level changing an outcome.

## Two decisions worth noting

**`401`, not a 302.** `ThargaControllerOptions.AuthenticationSchemes` names the API-key scheme explicitly. A policy naming no scheme authenticates against the application's *default* — OIDC in a Blazor host — so an unauthenticated API call gets redirected to a login page and an agent following it receives HTML with a `200`. This is the third appearance of that trap (`Tharga/Mcp#18` was the last); here it was configured rather than discovered.

**`403`, not `404`.** Naming a team you may not read returns `403`. A `404` would confirm whether a team exists to a caller not permitted to know.

## Also corrects a premise

An earlier note in the 06 spec said MCP "does not enforce" scopes, implying it bypasses the domain. That was wrong, and the spec now says so. MCP calls `ITeamService`, which *is* wrapped by `AuthorizationTeamServiceDecorator` — but that decorator gates **mutations** and **cross-team discovery** only; ordinary reads of a team the caller already holds a claim for are deliberate pass-throughs.

The real difference between the surfaces is narrower: **audit** is scope-gated everywhere, **team data** is scope-gated nowhere. That reframes the open phase-3 question from "why does MCP differ" to "should reading a team's own data be scope-gated at all" — a domain question, not an MCP defect.

## Scope

Read-only. List only — detail endpoints were dropped, which also removed the need to surface an id on `AuditEntry`.

**No version bump.** Purely additive; no consumer has to act.

## Tests

1114 passed, 0 failed.