### PR TITLE
The Not a member badge is drawn before the access level

### DIFF
--- a/Tharga.Team.Blazor.Tests/ConsentBadgeOrderTests.cs
+++ b/Tharga.Team.Blazor.Tests/ConsentBadgeOrderTests.cs
@@ -1,0 +1,102 @@
+using System.Text.RegularExpressions;
+
+namespace Tharga.Team.Blazor.Tests;
+
+/// <summary>
+/// The "Not a member" badge is drawn before the access level it qualifies.
+/// </summary>
+/// <remarks>
+/// A source scan, for the same reason <see cref="DialogButtonOrderTests"/> is one: badge order lives in
+/// markup and nothing in the compiled component records it. Both the card header and the grid's Consent
+/// column render the one fragment, so pinning it here covers every place a team badge appears.
+/// <para>
+/// Order carries meaning. Membership first reads as "not a member, but full access" — the qualifier
+/// arriving before the level it qualifies. Reversed, the level lands as a plain statement of the caller's
+/// standing and the correction comes too late to change it.
+/// </para>
+/// </remarks>
+public class ConsentBadgeOrderTests
+{
+    private const string MembershipBadge = "Text=\"Not a member\"";
+    private const string LevelBadge = "TeamVisibility.Label(";
+    private const string ComponentPath = "Tharga.Team.Blazor/Features/Team/TeamComponent.razor";
+
+    private static readonly Regex BadgeFragment = new(
+        @"private RenderFragment ConsentBadges\(.*?</text>;",
+        RegexOptions.Singleline | RegexOptions.Compiled);
+
+    private static DirectoryInfo RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !dir.GetDirectories("Tharga.Team.Blazor").Any()) dir = dir.Parent;
+        return dir;
+    }
+
+    private static string ConsentBadges()
+    {
+        var root = RepoRoot();
+        Assert.NotNull(root);
+
+        var markup = File.ReadAllText(Path.Combine(root.FullName, ComponentPath));
+        var fragment = BadgeFragment.Match(markup);
+
+        Assert.True(fragment.Success,
+            $"{ComponentPath}: no ConsentBadges render fragment found — the guard is scanning nothing.");
+
+        return fragment.Value;
+    }
+
+    private static (int Membership, int Level) Positions(string fragment) =>
+        (fragment.IndexOf(MembershipBadge, StringComparison.Ordinal),
+            fragment.IndexOf(LevelBadge, StringComparison.Ordinal));
+
+    [Fact]
+    public void MembershipIsDrawnBeforeTheAccessLevel()
+    {
+        var fragment = ConsentBadges();
+        var (membership, level) = Positions(fragment);
+
+        Assert.True(membership >= 0, $"{ComponentPath}: the 'Not a member' badge is gone from ConsentBadges.");
+        Assert.True(level >= 0, $"{ComponentPath}: the access level badge is gone from ConsentBadges.");
+        Assert.True(membership < level,
+            $"{ComponentPath}: the 'Not a member' badge is drawn after the access level; it belongs to " +
+            $"its left, so the qualifier is read before the level it qualifies.\n\n{fragment.Trim()}");
+    }
+
+    /// <summary>
+    /// The self-check: the scan found a fragment carrying both badges. A source scan that silently
+    /// matches nothing passes forever while reading as "the order is checked".
+    /// </summary>
+    [Fact]
+    public void TheGuard_FindsBothBadges()
+    {
+        var (membership, level) = Positions(ConsentBadges());
+
+        Assert.True(membership >= 0);
+        Assert.True(level >= 0);
+    }
+
+    /// <summary>And that it actually rejects the shape it exists to catch.</summary>
+    [Fact]
+    public void TheGuard_DetectsTheReversedOrder()
+    {
+        const string reversed = """
+            private RenderFragment ConsentBadges(ITeam<TMember> team) =>
+            @<text>
+                <RadzenStack Orientation="Orientation.Horizontal">
+                    <RadzenBadge Text="@TeamVisibility.Label(ConsentOf(team))" />
+                    <RadzenBadge Text="Not a member" />
+                </RadzenStack>
+            </text>;
+            """;
+
+        var fragment = BadgeFragment.Match(reversed);
+        Assert.True(fragment.Success);
+
+        var (membership, level) = Positions(fragment.Value);
+
+        Assert.True(membership >= 0);       // found both...
+        Assert.True(level >= 0);
+        Assert.False(membership < level);   // ...and the order is wrong, so the guard above would fail
+    }
+}

--- a/Tharga.Team.Blazor/Features/Team/TeamComponent.razor
+++ b/Tharga.Team.Blazor/Features/Team/TeamComponent.razor
@@ -852,11 +852,16 @@ else
     /// </para>
     /// </remarks>
     /// <summary>
-    /// What this team grants and whether the caller belongs to it, side by side.
+    /// Whether the caller belongs to this team and what it grants, side by side.
     /// </summary>
     /// <remarks>
-    /// Horizontal, because the two are one thought — "full access, but not a member" is the sentence an
+    /// Horizontal, because the two are one thought — "not a member, but full access" is the sentence an
     /// oversight caller is reading. Stacked, they looked like two unrelated properties.
+    /// <para>
+    /// Membership comes first because it qualifies the level that follows: the caller reads why they can
+    /// see the team before reading how much of it they get. Read the other way, the level lands as a plain
+    /// statement of their standing and the qualifier arrives too late to change it.
+    /// </para>
     /// <para>
     /// Read-only by design, which is what lets it sit in a card's <c>TopMenu</c>: that slot lives inside
     /// the header's click handler, so anything interactive there would toggle the card as well as itself.
@@ -865,17 +870,17 @@ else
     private RenderFragment ConsentBadges(ITeam<TMember> team) =>
     @<text>
         <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.35rem" Wrap="FlexWrap.Wrap">
+            @if (_canSeeAllTeams && !IsMemberOf(team))
+            {
+                <RadzenBadge BadgeStyle="BadgeStyle.Light" Variant="Variant.Flat" Text="Not a member"
+                             title="You are viewing this team through cross-team access, not membership." />
+            }
             @if (_canSeeAllTeams || _showConsentToggle)
             {
                 <RadzenBadge BadgeStyle="@(Enum.Parse<BadgeStyle>(TeamVisibility.BadgeStyle(ConsentOf(team))))"
                              Variant="Variant.Flat"
                              Text="@TeamVisibility.Label(ConsentOf(team))"
                              title="What this team has consented to grant. Select the team to change it." />
-            }
-            @if (_canSeeAllTeams && !IsMemberOf(team))
-            {
-                <RadzenBadge BadgeStyle="BadgeStyle.Light" Variant="Variant.Flat" Text="Not a member"
-                             title="You are viewing this team through cross-team access, not membership." />
             }
         </RadzenStack>
     </text>;

--- a/Tharga.Team.Blazor/README.md
+++ b/Tharga.Team.Blazor/README.md
@@ -172,8 +172,8 @@ to", and silently promoting that to a global enumeration privilege would widen a
 on upgrade.
 
 A holder of `teams:read` sees every team in `TeamComponent`, `TeamSelector` and `UsersView` → Teams,
-each tagged with what that team has consented to — **No access**, **Partial access** or **Full access** —
-plus a **Not a member** badge where applicable. You can select any team you can see, and the choice is
+each tagged with a **Not a member** badge where applicable, followed by what that team has consented to —
+**No access**, **Partial access** or **Full access**. You can select any team you can see, and the choice is
 remembered across visits — but selection grants no access by itself: a non-member gets scopes only where
 the team has consented to a role they hold. A team you never chose is never selected for you; when there
 is no current or remembered choice, the fallback comes from your own memberships. Enumeration is not

--- a/docs/articles/implementation-guide.md
+++ b/docs/articles/implementation-guide.md
@@ -1482,8 +1482,8 @@ access for existing hosts on upgrade, so it must be opted into. The flag compose
 `ConfigureSystemRoles` mapping for the same role rather than conflicting with it.
 
 **What a `teams:read` holder sees.** Each team carries a consent badge — *No access* (red), *Partial
-access* (yellow, Viewer/User) or *Full access* (green, Administrator) — plus a **Not a member** badge on
-teams they don't belong to. The `TeamSelector` shows the same state as a tinted dot.
+access* (yellow, Viewer/User) or *Full access* (green, Administrator) — preceded by a **Not a member**
+badge on teams they don't belong to, so the qualifier is read before the level it qualifies. The `TeamSelector` shows the same state as a tinted dot.
 
 **Selecting a team you don't belong to.** An oversight caller can select any team they can see, and that
 choice is remembered across visits like any other — returning to the site re-selects it. Selection on its


### PR DESCRIPTION
On the team list, the **Not a member** badge is now drawn to the **left** of the access-level badge.

```
before:   [ Full access ] [ Not a member ]
after:    [ Not a member ] [ Full access ]
```

Presentation only. No API change, no new option, nothing for a host to do.

## Why the order is the whole change

The two badges are one sentence, which is why they sit side by side rather than stacked. Read left to right, the new order says **"not a member, but full access"** — the qualifier arrives before the level it qualifies, so the reader learns *why* they can see the team before reading *how much* of it they get.

Reversed, it said **"full access, but not a member"**. The level lands first as a plain statement of the caller's standing, and the correction comes too late to change how it was read. For an oversight caller sweeping a list of teams they mostly don't belong to, that is the wrong way round on nearly every row.

## Where it shows

Only for a `teams:read` holder, and only on teams they are not a member of — the case the **Not a member** badge exists for. A member sees the consent badge alone, exactly as before.

Both places a team badge appears are covered, because both render one shared fragment:

- the **card title**, on a list short enough for cards
- the grid's **Consent column**, on a longer list where the row cannot be edited

## Pinned by a test, not by review

`ConsentBadgeOrderTests` scans the component source and asserts the membership badge precedes the level badge — the same approach as `DialogButtonOrderTests`, and for the same reason: badge order lives in markup, so there is nothing compiled to reflect over.

The scan carries its own self-checks, because a source scan that quietly matches nothing passes forever while reading as *"the order is checked"*. One test asserts the fragment was found with **both** badges in it; another feeds the scanner a reversed fragment and asserts it is rejected.

## Compatibility

Visual only — a package consumer picks this up by upgrading, with no code or configuration change. No dependency changes in this PR: the close-out `dotnet outdated` is clean apart from `SixLabors.ImageSharp` 4.0.0, which stays on 3.1.12 deliberately (4.0+ requires a paid Six Labors build-time license).

Documentation updated on both surfaces — the `Tharga.Team.Blazor` README and the implementation guide's *"What a `teams:read` holder sees"*.

Full suite green at 1735 tests across 7 projects.
