### PR TITLE
Pin Tharga Team's voice and label in project-name

### DIFF
--- a/.claude/project-name
+++ b/.claude/project-name
@@ -1,1 +1,3 @@
 Tharga Team
+voice: norman
+label: Tim


### PR DESCRIPTION
## What

Adds two lines to `.claude/project-name`:

```
Tharga Team
voice: norman
label: Tim
```

## Why

Spoken narration gives every project its own voice so concurrent Claude Code
sessions can be told apart by ear, and the status line names it —
`[Tharga Team - Tim]`.

Both of those were being read from `~/.claude/voices.json`, which lives on one
machine. So this project read `Tim` on the machine where that was set and
`Norman` everywhere else. `.claude/project-name` is checked in, so a project that
has said what it wants to sound like now says it on every machine that clones the
repo.

No behaviour change to anything the application does — this file is read only by
the narration hooks.

## Dependency

The `label:` line is understood by ClaudeVoice as of `3590eb0` on Eplicta
`develop`, which is pushed. An older ClaudeVoice ignores the line rather than
tripping over it, so this is safe to merge in either order — the name simply
stays `Norman` until that package reaches a given machine.