### PR TITLE
chore: drop the consumer-project reference and stop naming consumers in the priority rule

### DIFF
--- a/.claude/mission.md
+++ b/.claude/mission.md
@@ -17,8 +17,10 @@ When choosing what to work on, in this order:
 1. **Security and authorization.** Anything where the toolkit grants access it should not, or refuses
    access it should, comes first regardless of who asked. It is the one class of defect a consumer cannot
    work around and may not notice.
-2. **Eplicta and FortDocs.** Their asks before other consumers'.
-3. **Everything else** — other projects' requests, then internal work.
+2. **Anything a consumer cannot work around**, whoever filed it — a defect that blocks a consuming
+   product outranks internal work. No consumer is named or ranked above another here; rank the request,
+   not the requester.
+3. **Everything else** — other Tharga projects' requests, then internal work.
 
 Within a tier, a request someone actually filed outranks internal work. Say which tier a suggestion comes
 from when proposing what to do next, so the ordering is visible rather than implied.
@@ -64,4 +66,3 @@ for WebAssembly or a desktop client. Until then, incremental wins.
 - **Plan directory**: `$DOC_ROOT/Tharga/plans/Toolkit/Platform`
 - **Backlog**: `$DOC_ROOT/Tharga/Toolkit/Team.md` (renamed from `Platform.md` 2026-07-28)
 - **Incoming requests**: `$DOC_ROOT/Tharga/Requests.md` — check sections "Tharga.Team" and "Tharga.Team — MCP" on startup (renamed from "Tharga.Platform" 2026-07-28; individual entries below those headings still say Platform in their prose, which is historical and correct for when they were written).
-- **Eplicta requests**: `$DOC_ROOT/Eplicta/requests.md` — check for requests from Eplicta on startup


### PR DESCRIPTION
Documentation-only cleanup of `.claude/mission.md`. Part of an ecosystem-wide pass; the rules behind it now live in `shared-instructions.md` → *Feature Requests (cross-project)* → **External consumers**.

**Team is the only repo where this was more than deleting a stale path** — it had two references to a named consumer, and one of them was policy, not a pointer.

## 1. The reference path — removed

```diff
- **Eplicta requests**: `$DOC_ROOT/Eplicta/requests.md` — check for requests from Eplicta on startup
```

Worth noting this one had *already* rotted differently from its siblings: every other repo used `$DEV_ROOT/Eplicta/plan/requests.md`, while Team used `$DOC_ROOT/Eplicta/requests.md` — a different variable **and** a different filename. At least one of the two had been resolving to nothing for a while, which is exactly the failure the new rule describes: *"silently finds nothing reads identically to there was nothing pending."*

## 2. The priority rule — rewritten, not deleted

```diff
-2. **Eplicta and FortDocs.** Their asks before other consumers'.
-3. **Everything else** — other projects' requests, then internal work.
+2. **Anything a consumer cannot work around**, whoever filed it — a defect that blocks a consuming
+   product outranks internal work. No consumer is named or ranked above another here; rank the request,
+   not the requester.
+3. **Everything else** — other Tharga projects' requests, then internal work.
```

This tier existed for a real reason — consumer-blocking defects *should* outrank internal work — so it is kept. What is removed is naming who benefits.

Two problems with the old wording:

- **It silently outranked every consumer who was not mentioned.** A second consumer filing the same class of defect got lower priority for reasons found nowhere in the issue tracker.
- **The toolkit could not see the state of the commitment it was making.** Team had no way to know whether those products were still active, still consuming, or still cared.

Ranking the *kind* of request instead keeps the useful ordering and drops the part that cannot be verified from inside this repository.

## Inbound and outbound, after this

A consuming product raises a **GitHub issue on this repository** — the whole inbound channel. Outbound is a comment on that issue and nothing more: no follow-up entry, no adoption tracker, no writing into their files. Whoever asked tracks their own adoption.

Nothing is lost: open GitHub issues are already a mandatory request source on every startup, independent of what `mission.md` lists.

## Note on merging

Merging triggers the full CI pipeline including `release`, because no repo filters by path — so it publishes a new patch version identical in content to the current one. That is the only cost, and it is why this is left for you to merge. **Team also has 29 unreleased commits and in-flight work on `feature/simulation-followups`**, so its release is a bigger decision than the other repos' — this branch was cut from `origin/master` and does not touch that work.
