### PR TITLE
fix: support cases were unusable and startup could fail

### DIFF
--- a/Tharga.Team.Blazor.Tests/TeamPurgeCascadeLifetimeTests.cs
+++ b/Tharga.Team.Blazor.Tests/TeamPurgeCascadeLifetimeTests.cs
@@ -1,0 +1,85 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Tharga.Team.Blazor.Framework;
+using Tharga.Team.Service;
+
+namespace Tharga.Team.Blazor.Tests;
+
+/// <summary>
+/// <see cref="TeamPurgeCascade"/> must not outlive the stores its participants read.
+/// </summary>
+/// <remarks>
+/// <b>This shipped broken.</b> The cascade was registered as a singleton while every participant that exists
+/// — API keys, icons, support cases — reads a scoped store. That is not a subtle fault at purge time: the
+/// application will not start, with <c>Cannot consume scoped service … from singleton 'TeamPurgeCascade'</c>.
+/// It went unnoticed because container validation runs by default only in the Development environment, and
+/// no test built a container holding both the cascade and a participant.
+/// <para>
+/// <b>The guard registers a participant and builds the real container.</b> Asserting the descriptor's
+/// lifetime instead would be a test of the line rather than of the outcome — and would keep passing if the
+/// cascade later captured something else with a longer life.
+/// </para>
+/// </remarks>
+public class TeamPurgeCascadeLifetimeTests
+{
+    private const string ValidAzureAdConfig = """
+        {
+            "AzureAd": {
+                "Authority": "https://test.ciamlogin.com/test",
+                "ClientId": "test-client-id",
+                "TenantId": "test-tenant-id",
+                "CallbackPath": "/signin-oidc"
+            }
+        }
+        """;
+
+    /// <summary>Stands in for the shipped participants, every one of which reads a scoped store.</summary>
+    private sealed class ScopedStoreParticipant(ScopedStore store) : ITeamPurgeParticipant
+    {
+        public string Name => "test";
+
+        public Task<int> PurgeTeamDataAsync(string teamKey, CancellationToken cancellationToken = default)
+            => Task.FromResult(store == null ? 0 : 1);
+    }
+
+    private sealed class ScopedStore;
+
+    [Fact]
+    public void TheRealContainer_ValidatesWithAParticipantThatReadsAScopedStore()
+    {
+        var builder = WebApplication.CreateBuilder();
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(ValidAzureAdConfig));
+        builder.Configuration.AddJsonStream(stream);
+
+        builder.AddThargaTeam();
+
+        builder.Services.AddScoped<ScopedStore>();
+        builder.Services.AddTransient<ITeamPurgeParticipant, ScopedStoreParticipant>();
+
+        // Normally supplied by the Blazor and MongoDB runtimes.
+        builder.Services.AddSingleton<Microsoft.AspNetCore.Components.NavigationManager>(new TestNavigationManager());
+        builder.Services.AddSingleton(new Moq.Mock<Microsoft.JSInterop.IJSRuntime>().Object);
+        builder.Services.AddSingleton(new Moq.Mock<Tharga.MongoDB.IMongoDbServiceFactory>().Object);
+
+        // Building is the assertion. ValidateOnBuild is what produces "Cannot consume scoped service ...
+        // from singleton", which is the exact failure a host saw at startup, and it throws here rather than
+        // returning anything to inspect.
+        //
+        // Deliberately not resolved afterwards: the real participants construct MongoDB repositories, so
+        // resolving would test the mock factory rather than the lifetime.
+        using var provider = builder.Services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true });
+
+        Assert.NotNull(provider);
+
+        Assert.NotEqual(
+            ServiceLifetime.Singleton,
+            builder.Services.Single(x => x.ServiceType == typeof(TeamPurgeCascade)).Lifetime);
+    }
+
+    private class TestNavigationManager : Microsoft.AspNetCore.Components.NavigationManager
+    {
+        public TestNavigationManager() => Initialize("https://localhost/", "https://localhost/");
+    }
+}

--- a/Tharga.Team.Blazor/Framework/ThargaBlazorRegistration.cs
+++ b/Tharga.Team.Blazor/Framework/ThargaBlazorRegistration.cs
@@ -58,7 +58,11 @@ public static class ThargaBlazorRegistration
 
         // The composition root owns the cascade; each store registers its own ITeamPurgeParticipant. An
         // adapter package cannot register this - it depends on contracts, not on the domain.
-        services.TryAddSingleton<TeamPurgeCascade>();
+        //
+        // Scoped, not singleton: every participant reads a store, and those stores are scoped. It is only
+        // ever resolved from the scoped authorization decorator, so there is nothing to gain from a longer
+        // lifetime and a startup failure to lose.
+        services.TryAddScoped<TeamPurgeCascade>();
 
         if (o._teamService != null)
         {

--- a/Tharga.Team.Service/ControllersRegistration.cs
+++ b/Tharga.Team.Service/ControllersRegistration.cs
@@ -104,7 +104,10 @@ public static class ControllersRegistration
 
         // Purging a team must destroy its API keys. Purge drops the host's per-team database, which does
         // not reach this shared collection -- so without this a purged tenant's credentials outlive it.
-        services.TryAddSingleton<TeamPurgeCascade>();
+        //
+        // Scoped, not singleton: every participant reads a store, and those stores are scoped. A singleton
+        // capturing them fails container validation at startup rather than at purge time.
+        services.TryAddScoped<TeamPurgeCascade>();
         services.AddTransient<ITeamPurgeParticipant, ApiKeyPurgeParticipant>();
 
         return services;

--- a/Tharga.Team.Support.Tests/SupportRegistrationTests.cs
+++ b/Tharga.Team.Support.Tests/SupportRegistrationTests.cs
@@ -2,7 +2,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Tharga.Team.Service;
 using Tharga.Team.Service.Audit;
+using Tharga.Team.Support.Cases;
 using Tharga.Team.Support.Notifications;
 using Tharga.Team.Support.Slack;
 
@@ -77,6 +79,73 @@ public class SupportRegistrationTests
 
         Assert.Same(sink, asLogger);
         Assert.Same(sink, asHosted);
+    }
+
+    /// <summary>
+    /// <see cref="ISupportCaseService"/> can actually be resolved, not merely validated.
+    /// </summary>
+    /// <remarks>
+    /// <b>This shipped unresolvable.</b> <c>AddThargaSupportCases</c> built the service in a factory that
+    /// calls <c>GetRequiredService&lt;ISupportCaseNotifier&gt;()</c>, and nothing registered the notifier —
+    /// so every host got <c>No service for type 'ISupportCaseNotifier'</c> the first time a page injected
+    /// the case service, and the support feature could not be used at all.
+    /// <para>
+    /// <b>Container validation cannot catch this, which is the point of the test.</b> <c>ValidateOnBuild</c>
+    /// inspects constructor parameters; a service registered through a factory lambda is opaque to it, and
+    /// every dependency resolved inside that lambda is invisible until something asks for the service. The
+    /// only guard that works is resolving it.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void TheCaseService_Resolves()
+    {
+        using var provider = Build(s =>
+        {
+            // What a host supplies through AddThargaTeam and AddThargaAuditLogging. Everything the support
+            // package itself needs must come from AddThargaSupportCases.
+            s.AddSingleton(Substitute.For<ISupportCaseStore>());
+            s.AddSingleton(Substitute.For<ITeamPrincipalAccessor>());
+            s.AddSingleton<TeamAuthorizer>();
+            s.Configure<AuditOptions>(_ => { });
+            s.AddSingleton<CompositeAuditLogger>();
+            s.AddSingleton(Substitute.For<IAuditEntryFactory>());
+
+            s.AddThargaSupportCases();
+        });
+
+        using var scope = provider.CreateScope();
+
+        Assert.NotNull(scope.ServiceProvider.GetRequiredService<ISupportCaseService>());
+        Assert.NotNull(scope.ServiceProvider.GetRequiredService<ISupportCaseNotifier>());
+    }
+
+    /// <summary>
+    /// The notifier outlives every page that listens to it, and an inbound reply is raised from a different
+    /// scope than the circuit waiting for it.
+    /// </summary>
+    [Fact]
+    public void TheNotifier_IsOneInstanceForTheWholeApplication()
+    {
+        using var provider = Build(s =>
+        {
+            // What a host supplies through AddThargaTeam and AddThargaAuditLogging. Everything the support
+            // package itself needs must come from AddThargaSupportCases.
+            s.AddSingleton(Substitute.For<ISupportCaseStore>());
+            s.AddSingleton(Substitute.For<ITeamPrincipalAccessor>());
+            s.AddSingleton<TeamAuthorizer>();
+            s.Configure<AuditOptions>(_ => { });
+            s.AddSingleton<CompositeAuditLogger>();
+            s.AddSingleton(Substitute.For<IAuditEntryFactory>());
+
+            s.AddThargaSupportCases();
+        });
+
+        using var first = provider.CreateScope();
+        using var second = provider.CreateScope();
+
+        Assert.Same(
+            first.ServiceProvider.GetRequiredService<ISupportCaseNotifier>(),
+            second.ServiceProvider.GetRequiredService<ISupportCaseNotifier>());
     }
 
     /// <summary>

--- a/Tharga.Team.Support/SupportRegistration.cs
+++ b/Tharga.Team.Support/SupportRegistration.cs
@@ -105,6 +105,11 @@ public static class SupportRegistration
 
         services.TryAddSingleton(TimeProvider.System);
 
+        // Singleton, and it has to be: an inbound reply is handled in the poller's or the endpoint's own
+        // scope while the page waiting for it lives in a circuit's. A scoped notifier would raise the event
+        // on an instance nothing is listening to.
+        services.TryAddSingleton<ISupportCaseNotifier, SupportCaseNotifier>();
+
         // Purging a team destroys its cases. The store has exposed DeleteCasesForTeamAsync since the cases
         // shipped; this is the wiring that was missing, because the purge site could not reach the store.
         services.AddTransient<ITeamPurgeParticipant, SupportCasePurgeParticipant>();


### PR DESCRIPTION
Two registration defects that shipped in the 3.15/3.16 line. Between them, support cases could not be used at all, and an application could fail to start. Upgrading is the whole fix — no code or configuration changes are needed on your side.

## Support cases could not be used

Injecting `ISupportCaseService` threw as soon as anything asked for it:

```
System.InvalidOperationException: There is no registered service of type 'Tharga.Team.ISupportCaseNotifier'.
```

`AddThargaSupportCases` builds the case service from an `ISupportCaseNotifier`, and nothing registered one. Every call to `RaiseCaseAsync`, `ReplyToCaseAsync`, `GetMyCasesAsync` and the rest was unreachable, so the feature has never worked in a host since it was released.

**If you have been holding off on support cases because they did not work, this is why.** Nothing about the surface changes — the same registration call and the same contracts now resolve.

## An application could fail to start

Hosts that register API keys — and therefore most hosts — could fail at startup with:

```
System.AggregateException: Some services are not able to be constructed
(Cannot consume scoped service 'Tharga.Team.ISupportCaseStore'
 from singleton 'Tharga.Team.Service.TeamPurgeCascade')
```

The team-purge cascade, which destroys a team's API keys, icons and support cases when a team is purged, was registered with a longer lifetime than the stores it reads. It now matches them.

**You are most likely to have met this in Development**, because that is where the container is validated by default. The same misconfiguration in other environments would surface later instead, when a team was purged.

## Upgrading

Take the patch. There is no migration, no configuration change and no API change; purge behaviour and support-case behaviour are unchanged from what was documented.

Both faults are now covered by tests that fail without the fix, including one that resolves `ISupportCaseService` rather than only validating the container — the earlier tests passed because a service built inside a factory is invisible to container validation.
