### PR TITLE
Migrate the test suite to Microsoft.Testing.Platform (third attempt)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,8 +105,13 @@ jobs:
             exit 1
           fi
 
+      # Microsoft.Testing.Platform, not VSTest: xunit.v3 4.x drops the bridge, so
+      # --collect:"XPlat Code Coverage" (a VSTest data collector) no longer applies.
+      # --coverage needs Microsoft.Testing.Extensions.CodeCoverage referenced by every
+      # test project; requesting it without that reports "Zero tests ran" and exits 5,
+      # which reads as a fast pass rather than a failure.
       - name: Test with coverage
-        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
+        run: dotnet test -c Release --no-build --verbosity normal --coverage --coverage-output-format cobertura --results-directory ./coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/Tharga.Team.Blazor.Tests/AddThargaTeamTests.cs
+++ b/Tharga.Team.Blazor.Tests/AddThargaTeamTests.cs
@@ -255,7 +255,7 @@ public class AddThargaTeamTests
         Assert.Contains(builder.Services, d =>
             d.ServiceType == typeof(IApiKeyLifecycleHandler) && d.ImplementationType == typeof(TestLifecycleHandler));
         // Decoration replaces the IApiKeyAdministrationService registration with a factory.
-        var admin = Assert.Single(builder.Services.Where(d => d.ServiceType == typeof(IApiKeyAdministrationService)));
+        var admin = Assert.Single(builder.Services, d => d.ServiceType == typeof(IApiKeyAdministrationService));
         Assert.NotNull(admin.ImplementationFactory);
     }
 
@@ -273,7 +273,7 @@ public class AddThargaTeamTests
         var builder = CreateBuilder();
         builder.AddThargaTeam(o => o.Audit = new AuditOptions());
 
-        var admin = Assert.Single(builder.Services.Where(d => d.ServiceType == typeof(IApiKeyAdministrationService)));
+        var admin = Assert.Single(builder.Services, d => d.ServiceType == typeof(IApiKeyAdministrationService));
         Assert.NotNull(admin.ImplementationFactory);
         Assert.Null(admin.ImplementationType);
     }

--- a/Tharga.Team.Blazor.Tests/Tharga.Team.Blazor.Tests.csproj
+++ b/Tharga.Team.Blazor.Tests/Tharga.Team.Blazor.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <!-- Suppress xUnit1051: these fast in-memory unit tests don't need to thread TestContext.Current.CancellationToken. -->
@@ -8,17 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="bunit" Version="2.9.0" />
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/Tharga.Team.Entra.Tests/Tharga.Team.Entra.Tests.csproj
+++ b/Tharga.Team.Entra.Tests/Tharga.Team.Entra.Tests.csproj
@@ -1,23 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <!-- Suppress xUnit1051: these fast in-memory unit tests don't need to thread TestContext.Current.CancellationToken. -->
     <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.0" />
     <PackageReference Include="NSubstitute" Version="6.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/Tharga.Team.Images.Tests/Tharga.Team.Images.Tests.csproj
+++ b/Tharga.Team.Images.Tests/Tharga.Team.Images.Tests.csproj
@@ -1,22 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <!-- Suppress xUnit1051: these fast in-memory unit tests don't need to thread TestContext.Current.CancellationToken. -->
     <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.0" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Team.Images\Tharga.Team.Images.csproj" />

--- a/Tharga.Team.Images/Tharga.Team.Images.csproj
+++ b/Tharga.Team.Images/Tharga.Team.Images.csproj
@@ -33,7 +33,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="4.151.1" />
+    <PackageReference Include="SkiaSharp" Version="4.151.2" />
     <!--
       The self-contained libSkiaSharp.so, so a Linux host needs no fontconfig or freetype packages.
       Referenced here rather than left to the consumer: a missing native asset builds cleanly and fails
@@ -41,7 +41,7 @@
       The plain SkiaSharp.NativeAssets.Linux variant is smaller but pulls a font stack we never use —
       icons are decoded, scaled and encoded, never drawn with text.
     -->
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="4.151.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="4.151.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup>

--- a/Tharga.Team.Mcp.Tests/Tharga.Team.Mcp.Tests.csproj
+++ b/Tharga.Team.Mcp.Tests/Tharga.Team.Mcp.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <!-- Suppress xUnit1051: these fast in-memory unit tests don't need to thread TestContext.Current.CancellationToken. -->
@@ -8,18 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.11" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.0" />
     <PackageReference Include="NSubstitute" Version="6.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Team.Mcp\Tharga.Team.Mcp.csproj" />

--- a/Tharga.Team.MongoDB.Tests/Tharga.Team.MongoDB.Tests.csproj
+++ b/Tharga.Team.MongoDB.Tests/Tharga.Team.MongoDB.Tests.csproj
@@ -1,23 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <!-- Suppress xUnit1051: these fast in-memory unit tests don't need to thread TestContext.Current.CancellationToken. -->
     <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.0" />
     <PackageReference Include="NSubstitute" Version="6.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Team.MongoDB\Tharga.Team.MongoDB.csproj" />

--- a/Tharga.Team.Service.Tests/ApiKeyAuditWiringTests.cs
+++ b/Tharga.Team.Service.Tests/ApiKeyAuditWiringTests.cs
@@ -56,7 +56,7 @@ public class ApiKeyAuditWiringTests
         services.AddAuditedApiKeyAdministrationService(typeof(ApiKeyAdministrationService));
         services.AddAuditedApiKeyAdministrationService(typeof(ApiKeyAdministrationService));
 
-        Assert.Single(services.Where(d => d.ServiceType == typeof(IApiKeyAdministrationService)));
+        Assert.Single(services, d => d.ServiceType == typeof(IApiKeyAdministrationService));
         var resolved = services.BuildServiceProvider().GetRequiredService<IApiKeyAdministrationService>();
         Assert.IsType<AuditingApiKeyServiceDecorator>(resolved);
     }

--- a/Tharga.Team.Service.Tests/Tharga.Team.Service.Tests.csproj
+++ b/Tharga.Team.Service.Tests/Tharga.Team.Service.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <!-- Suppress xUnit1051: these fast in-memory unit tests don't need to thread TestContext.Current.CancellationToken. -->
@@ -8,18 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.11" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.0" />
     <PackageReference Include="NSubstitute" Version="6.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Team.Service\Tharga.Team.Service.csproj" />

--- a/Tharga.Team.Support.Tests/Tharga.Team.Support.Tests.csproj
+++ b/Tharga.Team.Support.Tests/Tharga.Team.Support.Tests.csproj
@@ -1,23 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <!-- Suppress xUnit1051: these fast in-memory unit tests don't need to thread TestContext.Current.CancellationToken. -->
     <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.0" />
     <PackageReference Include="NSubstitute" Version="6.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.Team.Support\Tharga.Team.Support.csproj" />

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}


### PR DESCRIPTION
Moves the repo's own test suite from the VSTest bridge to Microsoft.Testing.Platform, and takes the two available package updates.

**No consumer-facing change.** Nothing in any shipped package moves — this is test infrastructure and one patch bump.

## Why this is its own PR

**This migration has been attempted twice and backed out both times.** Both attempts were green on Windows and failed on the Ubuntu runner: coverage instrumentation left `Tharga.Team.Mcp.Tests.dll` unloadable with `System.BadImageFormatException`, so it reported *"Zero tests ran"* and the run aborted at exit 134 having run 1940 of 2047 tests. The other six projects passed.

It needs Linux-side iteration, which is exactly why it does not belong inside a feature PR. It started bundled into #251 and was split back out before pushing.

## What this attempt changes

Everything the previous attempts established is applied unchanged:

- `global.json` opts into the MTP runner (`{ "test": { "runner": "Microsoft.Testing.Platform" } }`) — this is the opt-in, not `dotnet.config`. No SDK version is pinned, since CI and local machines differ.
- Each test project gains `<OutputType>Exe</OutputType>`, now required once `Microsoft.NET.Test.Sdk` goes.
- `Microsoft.NET.Test.Sdk`, `xunit.runner.visualstudio` and `coverlet.collector` are dropped as VSTest-only; `xunit.v3` goes to 4.0.0.
- CI moves from `--collect:"XPlat Code Coverage"` to `--coverage --coverage-output-format cobertura`. The files land flat as `./coverage/<guid>.cobertura.xml` rather than nested, which the Codecov step reads either way.

**The one deliberate difference: `Microsoft.Testing.Extensions.CodeCoverage` 18.11.0, where the last attempt used 18.3.1.** That is the entire experiment this PR runs. If the `BadImageFormatException` was an instrumenter bug, eight minor versions may have fixed it.

**If CI aborts at exit 134 again, the version was never the cause** — and the next step is already decided: push this same branch with `--coverage` removed from the CI test step, which separates "MTP does not work on Linux here" from "the instrumenter corrupts that one assembly". That fork cannot be resolved from Windows.

## Also here

- `SkiaSharp` and `SkiaSharp.NativeAssets.Linux.NoDependencies` 4.151.1 → 4.151.2 (patch).
- Three `xUnit2031` warnings introduced by the 4.x analyzers, fixed rather than suppressed (`Assert.Single(x.Where(p))` → `Assert.Single(x, p)`), so the upgrade does not push CI toward its 35-warning threshold.

## Status

**Windows-green at 2481 tests — which is what both previous attempts also achieved, and proves nothing.** The Ubuntu run on this PR is the actual result being sought.
